### PR TITLE
Estructura y almacenamiento de roles

### DIFF
--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -65,7 +65,6 @@ func (rs *RoleStore) Close() error {
 func NewRoleStore(path string, readOnly bool) (*RoleStore, error) {
 	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: readOnly})
 	if err != nil {
-		db.Close()
 		return nil, fmt.Errorf("error abriendo %q: %w", path, err)
 	}
 
@@ -73,6 +72,7 @@ func NewRoleStore(path string, readOnly bool) (*RoleStore, error) {
 
 	if !readOnly {
 		if err := rs.init(); err != nil {
+			db.Close()
 			return nil, err
 		}
 	}

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -43,8 +43,14 @@ func (rs *RoleStore) init() error {
 		for _, name := range []string{AdminRole, DefaultRole} {
 			if b.Get([]byte(name)) == nil {
 				role := Role{Name: name, CreatedAt: time.Now()}
-				data, _ := json.Marshal(role)
-				b.Put([]byte(name), data)
+				data, err := json.Marshal(role)
+				if err != nil {
+					return err
+				}
+				if err := b.Put([]byte(name), data); err != nil {
+					return err
+				}
+
 			}
 		}
 
@@ -57,9 +63,10 @@ func (rs *RoleStore) Close() error {
 }
 
 func NewRoleStore(path string, readOnly bool) (*RoleStore, error) {
-	db, err := bolt.Open(path, 0666, &bolt.Options{ReadOnly: readOnly})
+	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: readOnly})
 	if err != nil {
-		return nil, fmt.Errorf("error abriendo roles.db: %w", err)
+		db.Close()
+		return nil, fmt.Errorf("error abriendo %q: %w", path, err)
 	}
 
 	rs := &RoleStore{db: db}
@@ -78,6 +85,10 @@ func NewRoleStore(path string, readOnly bool) (*RoleStore, error) {
 func (rs *RoleStore) CreateRole(name string) error {
 	return rs.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucketRoles))
+		if b == nil {
+			return fmt.Errorf("bucket de roles no encontrado")
+		}
+
 		if b.Get([]byte(name)) != nil {
 			return fmt.Errorf("el rol '%s' ya existe", name)
 		}
@@ -93,6 +104,10 @@ func (rs *RoleStore) CreateRole(name string) error {
 func (rs *RoleStore) DeleteRole(name string) error {
 	return rs.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucketRoles))
+		if b == nil {
+			return fmt.Errorf("bucket de roles no encontrado")
+		}
+
 		if b.Get([]byte(name)) == nil {
 			return fmt.Errorf("el rol '%s' no existe", name)
 		}
@@ -104,6 +119,10 @@ func (rs *RoleStore) ListRoles() ([]Role, error) {
 	var roles []Role
 	err := rs.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucketRoles))
+		if b == nil {
+			return fmt.Errorf("bucket de roles no encontrado")
+		}
+
 		return b.ForEach(func(k, v []byte) error {
 			var role Role
 			if err := json.Unmarshal(v, &role); err != nil {
@@ -120,6 +139,10 @@ func (rs *RoleStore) RoleExists(name string) (bool, error) {
 	var exists bool
 	err := rs.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucketRoles))
+		if b == nil {
+			return fmt.Errorf("bucket de roles no encontrado")
+		}
+
 		exists = b.Get([]byte(name)) != nil
 		return nil
 	})

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -1,0 +1,127 @@
+package roles
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	bucketRoles     = "roles"
+	bucketUserRoles = "user_roles"
+	DefaultRole     = "user"
+	AdminRole       = "admin"
+)
+
+type Role struct {
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type UserRoles struct {
+	Username string   `json:"username"`
+	Roles    []string `json:"roles"`
+}
+
+type RoleStore struct {
+	db *bolt.DB
+}
+
+func (rs *RoleStore) init() error {
+	return rs.db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists([]byte(bucketRoles)); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists([]byte(bucketUserRoles)); err != nil {
+			return err
+		}
+
+		// Creo roles por defecto
+		b := tx.Bucket([]byte(bucketRoles))
+		for _, name := range []string{AdminRole, DefaultRole} {
+			if b.Get([]byte(name)) == nil {
+				role := Role{Name: name, CreatedAt: time.Now()}
+				data, _ := json.Marshal(role)
+				b.Put([]byte(name), data)
+			}
+		}
+
+		return nil
+	})
+}
+
+func (rs *RoleStore) Close() error {
+	return rs.db.Close()
+}
+
+func NewRoleStore(path string, readOnly bool) (*RoleStore, error) {
+	db, err := bolt.Open(path, 0666, &bolt.Options{ReadOnly: readOnly})
+	if err != nil {
+		return nil, fmt.Errorf("error abriendo roles.db: %w", err)
+	}
+
+	rs := &RoleStore{db: db}
+
+	if !readOnly {
+		if err := rs.init(); err != nil {
+			return nil, err
+		}
+	}
+
+	return rs, nil
+}
+
+// Funciones CRUD de roles
+
+func (rs *RoleStore) CreateRole(name string) error {
+	return rs.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketRoles))
+		if b.Get([]byte(name)) != nil {
+			return fmt.Errorf("el rol '%s' ya existe", name)
+		}
+		role := Role{Name: name, CreatedAt: time.Now()}
+		data, err := json.Marshal(role)
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(name), data)
+	})
+}
+
+func (rs *RoleStore) DeleteRole(name string) error {
+	return rs.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketRoles))
+		if b.Get([]byte(name)) == nil {
+			return fmt.Errorf("el rol '%s' no existe", name)
+		}
+		return b.Delete([]byte(name))
+	})
+}
+
+func (rs *RoleStore) ListRoles() ([]Role, error) {
+	var roles []Role
+	err := rs.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketRoles))
+		return b.ForEach(func(k, v []byte) error {
+			var role Role
+			if err := json.Unmarshal(v, &role); err != nil {
+				return err
+			}
+			roles = append(roles, role)
+			return nil
+		})
+	})
+	return roles, err
+}
+
+func (rs *RoleStore) RoleExists(name string) (bool, error) {
+	var exists bool
+	err := rs.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketRoles))
+		exists = b.Get([]byte(name)) != nil
+		return nil
+	})
+	return exists, err
+}

--- a/pkg/roles/roles_test.go
+++ b/pkg/roles/roles_test.go
@@ -1,0 +1,162 @@
+package roles
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func newTestRoleStore(t *testing.T) *RoleStore {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "roles.db")
+
+	rs, err := NewRoleStore(path, false)
+	if err != nil {
+		t.Fatalf("no se ha podido crear la store de pruebas: %v", err)
+	}
+	t.Cleanup(func() { _ = rs.Close() })
+
+	return rs
+}
+
+func TestRoleStore_DefaultRolesCreated(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	for _, name := range []string{AdminRole, DefaultRole} {
+		exists, err := rs.RoleExists(name)
+		if err != nil {
+			t.Fatalf("RoleExists(%q) falló: %v", name, err)
+		}
+		if !exists {
+			t.Fatalf("se esperaba que el rol %q existiera por defecto", name)
+		}
+	}
+}
+
+func TestRoleStore_CreateRole(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.CreateRole("moderator"); err != nil {
+		t.Fatalf("CreateRole falló: %v", err)
+	}
+
+	exists, err := rs.RoleExists("moderator")
+	if err != nil {
+		t.Fatalf("RoleExists falló: %v", err)
+	}
+	if !exists {
+		t.Fatal("el rol 'moderator' debería existir tras crearlo")
+	}
+}
+
+func TestRoleStore_CreateRoleDuplicate(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.CreateRole("moderator"); err != nil {
+		t.Fatalf("primera CreateRole falló: %v", err)
+	}
+	if err := rs.CreateRole("moderator"); err == nil {
+		t.Fatal("se esperaba error al crear un rol duplicado")
+	}
+}
+
+func TestRoleStore_DeleteRole(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.CreateRole("temporal"); err != nil {
+		t.Fatalf("CreateRole falló: %v", err)
+	}
+	if err := rs.DeleteRole("temporal"); err != nil {
+		t.Fatalf("DeleteRole falló: %v", err)
+	}
+
+	exists, err := rs.RoleExists("temporal")
+	if err != nil {
+		t.Fatalf("RoleExists falló: %v", err)
+	}
+	if exists {
+		t.Fatal("el rol 'temporal' no debería existir tras eliminarlo")
+	}
+}
+
+func TestRoleStore_DeleteRoleNotFound(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.DeleteRole("noexiste"); err == nil {
+		t.Fatal("se esperaba error al eliminar un rol inexistente")
+	}
+}
+
+func TestRoleStore_ListRoles(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	roles, err := rs.ListRoles()
+	if err != nil {
+		t.Fatalf("ListRoles falló: %v", err)
+	}
+
+	found := make(map[string]bool)
+	for _, r := range roles {
+		found[r.Name] = true
+	}
+
+	for _, name := range []string{AdminRole, DefaultRole} {
+		if !found[name] {
+			t.Fatalf("ListRoles debería incluir el rol %q por defecto", name)
+		}
+	}
+}
+
+func TestRoleStore_RoleExists(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	exists, err := rs.RoleExists("noexiste")
+	if err != nil {
+		t.Fatalf("RoleExists falló: %v", err)
+	}
+	if exists {
+		t.Fatal("RoleExists debería devolver false para un rol inexistente")
+	}
+
+	exists, err = rs.RoleExists(AdminRole)
+	if err != nil {
+		t.Fatalf("RoleExists falló: %v", err)
+	}
+	if !exists {
+		t.Fatalf("RoleExists debería devolver true para %q", AdminRole)
+	}
+}
+
+func TestRoleStore_PersistsOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "roles.db")
+
+	{
+		rs, err := NewRoleStore(path, false)
+		if err != nil {
+			t.Fatalf("open falló: %v", err)
+		}
+		if err := rs.CreateRole("moderator"); err != nil {
+			_ = rs.Close()
+			t.Fatalf("CreateRole falló: %v", err)
+		}
+		_ = rs.Close()
+	}
+
+	{
+		rs, err := NewRoleStore(path, false)
+		if err != nil {
+			t.Fatalf("re-open falló: %v", err)
+		}
+		defer rs.Close()
+
+		exists, err := rs.RoleExists("moderator")
+		if err != nil {
+			t.Fatalf("RoleExists tras re-open falló: %v", err)
+		}
+		if !exists {
+			t.Fatal("el rol 'moderator' debería persistir tras cerrar y reabrir la store")
+		}
+	}
+}


### PR DESCRIPTION
## Referencias
Closes #23 

## Descripción
Añade el paquete `pkg/roles` con la estructura `RoleStore` sobre bbolt. Incluye CRUD de roles y creación automática de los roles `admin` y `user` al inicializar la base de datos. Base para el sistema de autorización.

## Tipo de cambio

- [X] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Seguridad
- [ ] Refactor

## Checklist

- [X] El servidor arranca sin errores (`go run main.go`)
- [X] He probado el flujo completo (registro → login → operación → logout)
- [X] No hay contraseñas ni secretos hardcodeados

## Revisión

### Revisores
<!-- Añade los revisores que deben aprobar este PR -->
<!--   - @usuario1 -->
- @msb104 

## Checklist de revisión

* [x] El código compila sin errores (`go build ./...`)
* [x] Los tests pasan (`go test ./...`)
* [x] No hay contraseñas ni secretos hardcodeados
* [x] Los errores se manejan correctamente (no hay `_` ignorando errores importantes)
* [x] Las funciones nuevas son coherentes con el estilo del resto del proyecto
* [x] No se exponen endpoints innecesarios
* [x] He probado el flujo manualmente