### PR TITLE
Generación y almacenamiento de claves

### DIFF
--- a/pkg/utils/keys.go
+++ b/pkg/utils/keys.go
@@ -7,12 +7,23 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"golang.org/x/crypto/argon2"
 )
+
+const keyFileVersion = 1
+
+type keyFile struct {
+	Version   int    `json:"version"`
+	KDF       string `json:"kdf"`
+	Cipher    string `json:"cipher"`
+	Salt      []byte `json:"salt"`
+	Encrypted []byte `json:"encrypted"`
+}
 
 func keyPath(username string) string {
 	hash := sha256.Sum256([]byte(username))
@@ -35,7 +46,7 @@ func EncryptPrivateKey(sk ed25519.PrivateKey, password, username string) error {
 		return fmt.Errorf("error generando salt: %w", err)
 	}
 
-	// Derivo clave AES de 32 bytes a partir de la cotraseña
+	// Derivo clave AES de 32 bytes a partir de la contraseña
 	key := argon2.IDKey([]byte(password), salt, 1, 64*1024, 4, 32)
 
 	// Creo el cifrador AES-GCM
@@ -58,13 +69,28 @@ func EncryptPrivateKey(sk ed25519.PrivateKey, password, username string) error {
 	// Cifro la clave privada
 	encrypted := gcm.Seal(nonce, nonce, sk, nil)
 
-	// Guardo salt + datos cifrados en disco
-	fileData := append(salt, encrypted...)
+	// Guardo archivo en el disco
+	kf := keyFile{
+		Version:   keyFileVersion,
+		KDF:       "argon2id",
+		Cipher:    "aes-256-gcm",
+		Salt:      salt,
+		Encrypted: encrypted,
+	}
+
+	fileData, err := json.Marshal(kf)
+	if err != nil {
+		return fmt.Errorf("error serializando archivo de clave: %w", err)
+	}
 	path := keyPath(username)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("error creando directorio: %w", err)
 	}
-	return os.WriteFile(path, fileData, 0600)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, fileData, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 func DecryptPrivateKey(password, username string) (ed25519.PrivateKey, error) {
@@ -75,12 +101,18 @@ func DecryptPrivateKey(password, username string) (ed25519.PrivateKey, error) {
 		return nil, fmt.Errorf("error leyendo clave privada: %w", err)
 	}
 
-	// Separo salt
-	if len(fileData) < 16 {
-		return nil, fmt.Errorf("archivo de clave corrupto")
+	var kf keyFile
+	if err := json.Unmarshal(fileData, &kf); err != nil {
+		return nil, fmt.Errorf("archivo de clave corrupto: %w", err)
 	}
-	salt := fileData[:16]
-	encrypted := fileData[16:]
+	if kf.Version != keyFileVersion {
+		return nil, fmt.Errorf("versión de archivo de clave no soportada: %d", kf.Version)
+	}
+	if kf.KDF != "argon2id" || kf.Cipher != "aes-256-gcm" {
+		return nil, fmt.Errorf("algoritmo no soportado: %s/%s", kf.KDF, kf.Cipher)
+	}
+	salt := kf.Salt
+	encrypted := kf.Encrypted
 
 	// Derivo la misma clave AES con la contraseña y el salt
 	key := argon2.IDKey([]byte(password), salt, 1, 64*1024, 4, 32)
@@ -105,7 +137,10 @@ func DecryptPrivateKey(password, username string) (ed25519.PrivateKey, error) {
 	// Descifro
 	sk, err := gcm.Open(nil, nonce, cipherText, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error descifrando clave privada, contraseña incorrecta")
+		return nil, fmt.Errorf("error descifrando clave privada, contraseña incorrecta o achivo de clave corrupto/manipulado")
+	}
+	if len(sk) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("clave privada corrupta o inválida")
 	}
 
 	return ed25519.PrivateKey(sk), nil

--- a/pkg/utils/keys.go
+++ b/pkg/utils/keys.go
@@ -1,0 +1,112 @@
+package utils
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/crypto/argon2"
+)
+
+func keyPath(username string) string {
+	hash := sha256.Sum256([]byte(username))
+	return filepath.Join("data", "keys", hex.EncodeToString(hash[:])+".key")
+}
+
+func GenerateKeyPair() (ed25519.PublicKey, ed25519.PrivateKey, error) {
+	pk, sk, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error generando par de claves: %w", err)
+	}
+	return pk, sk, nil
+}
+
+func EncryptPrivateKey(sk ed25519.PrivateKey, password, username string) error {
+
+	// Genero salt aleatorio para Argon2
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return fmt.Errorf("error generando salt: %w", err)
+	}
+
+	// Derivo clave AES de 32 bytes a partir de la cotraseña
+	key := argon2.IDKey([]byte(password), salt, 1, 64*1024, 4, 32)
+
+	// Creo el cifrador AES-GCM
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return fmt.Errorf("error creando cifrador: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("error creando GCM: %w", err)
+	}
+
+	// Genero nonce aleatorio
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return fmt.Errorf("error generando nonce: %w", err)
+	}
+
+	// Cifro la clave privada
+	encrypted := gcm.Seal(nonce, nonce, sk, nil)
+
+	// Guardo salt + datos cifrados en disco
+	fileData := append(salt, encrypted...)
+	path := keyPath(username)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("error creando directorio: %w", err)
+	}
+	return os.WriteFile(path, fileData, 0600)
+}
+
+func DecryptPrivateKey(password, username string) (ed25519.PrivateKey, error) {
+	// Leo el archivo
+	path := keyPath(username)
+	fileData, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error leyendo clave privada: %w", err)
+	}
+
+	// Separo salt
+	if len(fileData) < 16 {
+		return nil, fmt.Errorf("archivo de clave corrupto")
+	}
+	salt := fileData[:16]
+	encrypted := fileData[16:]
+
+	// Derivo la misma clave AES con la contraseña y el salt
+	key := argon2.IDKey([]byte(password), salt, 1, 64*1024, 4, 32)
+
+	// Creo el cifrador AES-GCM
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("error creando cifrador: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("error creando GCM: %w", err)
+	}
+
+	// Separo nonce del contenido cifrado
+	if len(encrypted) < gcm.NonceSize() {
+		return nil, fmt.Errorf("archivo de clave corrupto")
+	}
+	nonce := encrypted[:gcm.NonceSize()]
+	cipherText := encrypted[gcm.NonceSize():]
+
+	// Descifro
+	sk, err := gcm.Open(nil, nonce, cipherText, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error descifrando clave privada, contraseña incorrecta")
+	}
+
+	return ed25519.PrivateKey(sk), nil
+}

--- a/pkg/utils/keys_test.go
+++ b/pkg/utils/keys_test.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKeyRoundTrip(t *testing.T) {
+	pk, sk, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("error generando par de claves: %v", err)
+	}
+	if len(pk) != ed25519.PublicKeySize {
+		t.Fatalf("pk tiene longitud incorrecta: %d", len(pk))
+	}
+	if len(sk) != ed25519.PrivateKeySize {
+		t.Fatalf("sk tiene longitud incorrecta: %d", len(sk))
+	}
+
+	username := "testuser"
+	password := "contraseña-segura"
+
+	if err := EncryptPrivateKey(sk, password, username); err != nil {
+		t.Fatalf("error cifrando clave privada: %v", err)
+	}
+
+	recovered, err := DecryptPrivateKey(password, username)
+	if err != nil {
+		t.Fatalf("error descifrando clave privada: %v", err)
+	}
+
+	if !recovered.Equal(sk) {
+		t.Fatal("la clave recuperada no coincide con la original")
+	}
+}
+
+func TestDecryptWrongPassword(t *testing.T) {
+	_, sk, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("error generando par de claves: %v", err)
+	}
+
+	username := "testuser2"
+	if err := EncryptPrivateKey(sk, "contraseña-correcta", username); err != nil {
+		t.Fatalf("error cifrando clave privada: %v", err)
+	}
+
+	_, err = DecryptPrivateKey("contraseña-incorrecta", username)
+	if err == nil {
+		t.Fatal("debería haber fallado con contraseña incorrecta")
+	}
+}
+
+func TestDecryptCorruptFile(t *testing.T) {
+	username := "testuser3"
+	path := keyPath(username)
+
+	// Escribe datos corruptos
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("error creando directorio: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("datos corruptos"), 0600); err != nil {
+		t.Fatalf("error escribiendo archivo corrupto: %v", err)
+	}
+
+	_, err := DecryptPrivateKey("cualquier-password", username)
+	if err == nil {
+		t.Fatal("debería haber fallado con archivo corrupto")
+	}
+}

--- a/pkg/utils/keys_test.go
+++ b/pkg/utils/keys_test.go
@@ -7,7 +7,19 @@ import (
 	"testing"
 )
 
+func TestMain(m *testing.M) {
+	code := m.Run()
+	os.RemoveAll(filepath.Join("data", "keys"))
+	os.RemoveAll("data")
+	os.Exit(code)
+}
+
 func TestKeyRoundTrip(t *testing.T) {
+	username := "testuser"
+	t.Cleanup(func() {
+		os.Remove(keyPath(username))
+	})
+
 	pk, sk, err := GenerateKeyPair()
 	if err != nil {
 		t.Fatalf("error generando par de claves: %v", err)
@@ -19,7 +31,6 @@ func TestKeyRoundTrip(t *testing.T) {
 		t.Fatalf("sk tiene longitud incorrecta: %d", len(sk))
 	}
 
-	username := "testuser"
 	password := "contraseña-segura"
 
 	if err := EncryptPrivateKey(sk, password, username); err != nil {
@@ -37,12 +48,16 @@ func TestKeyRoundTrip(t *testing.T) {
 }
 
 func TestDecryptWrongPassword(t *testing.T) {
+	username := "testuser2"
+	t.Cleanup(func() {
+		os.Remove(keyPath(username))
+	})
+
 	_, sk, err := GenerateKeyPair()
 	if err != nil {
 		t.Fatalf("error generando par de claves: %v", err)
 	}
 
-	username := "testuser2"
 	if err := EncryptPrivateKey(sk, "contraseña-correcta", username); err != nil {
 		t.Fatalf("error cifrando clave privada: %v", err)
 	}
@@ -56,12 +71,14 @@ func TestDecryptWrongPassword(t *testing.T) {
 func TestDecryptCorruptFile(t *testing.T) {
 	username := "testuser3"
 	path := keyPath(username)
+	t.Cleanup(func() {
+		os.Remove(path)
+	})
 
-	// Escribe datos corruptos
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("error creando directorio: %v", err)
 	}
-	if err := os.WriteFile(path, []byte("datos corruptos"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte("{json corrupto}"), 0600); err != nil {
 		t.Fatalf("error escribiendo archivo corrupto: %v", err)
 	}
 


### PR DESCRIPTION
## Referencias
Closes #28 

## Descripción
Añade `pkg/utils/keys.go` con generación de par de claves Ed25519 y almacenamiento cifrado de la clave privada con AES-GCM + Argon2id. La clave privada se guarda en disco bajo el hash del username para no revelar qué usuarios tienen clave registrada.

## Tipo de cambio

- [X] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Seguridad
- [ ] Refactor

## Checklist

- [X] El servidor arranca sin errores (`go run main.go`)
- [X] He probado el flujo completo (registro → login → operación → logout)
- [X] No hay contraseñas ni secretos hardcodeados

## Revisión

### Revisores
<!-- Añade los revisores que deben aprobar este PR -->
<!--   - @usuario1 -->
- @msb104 


## Checklist de revisión

* [x] El código compila sin errores (`go build ./...`)
* [x] Los tests pasan (`go test ./...`)
* [x] No hay contraseñas ni secretos hardcodeados
* [x] Los errores se manejan correctamente (no hay `_` ignorando errores importantes)
* [x] Las funciones nuevas son coherentes con el estilo del resto del proyecto
* [x] No se exponen endpoints innecesarios
* [x] He probado el flujo manualmente