### PR TITLE
24 cli de administración

### DIFF
--- a/pkg/admin/main.go
+++ b/pkg/admin/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"sprout/pkg/roles"
 	"sprout/pkg/ui"
 )
@@ -9,6 +10,10 @@ import (
 const rolesDBPath = "data/roles.db"
 
 func main() {
+	if err := os.MkdirAll("data", 0755); err != nil {
+		fmt.Printf("Error creando directorio data : %v\n", err)
+		return
+	}
 	rs, err := roles.NewRoleStore(rolesDBPath, false)
 	if err != nil {
 		fmt.Printf("Error abriendo roles.db: %v\n", err)
@@ -67,7 +72,7 @@ func listarRoles(rs *roles.RoleStore) {
 
 func crearRol(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	nombre := ui.ReadInput("Nombre del rol: ")
+	nombre := ui.ReadInput("Nombre del rol ")
 	if err := rs.CreateRole(nombre); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -77,7 +82,7 @@ func crearRol(rs *roles.RoleStore) {
 
 func eliminarRol(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	nombre := ui.ReadInput("Nombre del rol a eliminar: ")
+	nombre := ui.ReadInput("Nombre del rol a eliminar ")
 	if err := rs.DeleteRole(nombre); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -87,8 +92,8 @@ func eliminarRol(rs *roles.RoleStore) {
 
 func asignarRol(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	usuario := ui.ReadInput("Nombre de usuario: ")
-	rol := ui.ReadInput("Rol a asignar: ")
+	usuario := ui.ReadInput("Nombre de usuario ")
+	rol := ui.ReadInput("Rol a asignar ")
 	if err := rs.AssignRole(usuario, rol); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -98,8 +103,8 @@ func asignarRol(rs *roles.RoleStore) {
 
 func quitarRol(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	usuario := ui.ReadInput("Nombre de usuario: ")
-	rol := ui.ReadInput("Rol a quitar: ")
+	usuario := ui.ReadInput("Nombre de usuario ")
+	rol := ui.ReadInput("Rol a quitar ")
 	if err := rs.RemoveRole(usuario, rol); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -109,7 +114,7 @@ func quitarRol(rs *roles.RoleStore) {
 
 func verRolesUsuario(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	usuario := ui.ReadInput("Nombre de usuario: ")
+	usuario := ui.ReadInput("Nombre de usuario ")
 	list, err := rs.GetUserRoles(usuario)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)

--- a/pkg/admin/main.go
+++ b/pkg/admin/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"sprout/pkg/roles"
+	"sprout/pkg/ui"
+)
+
+const rolesDBPath = "data/roles.db"
+
+func main() {
+	rs, err := roles.NewRoleStore(rolesDBPath, false)
+	if err != nil {
+		fmt.Printf("Error abriendo roles.db: %v\n", err)
+		return
+	}
+	defer rs.Close()
+
+	for {
+		ui.ClearScreen()
+		opcion := ui.PrintMenu("=== Sprout Admin ===", []string{
+			"Listar roles",
+			"Crear rol",
+			"Eliminar rol",
+			"Asignar rol a usuario",
+			"Quitar rol a usuario",
+			"Ver roles de un usuario",
+			"Salir",
+		})
+
+		switch opcion {
+		case 1:
+			listarRoles(rs)
+		case 2:
+			crearRol(rs)
+		case 3:
+			eliminarRol(rs)
+		case 4:
+			asignarRol(rs)
+		case 5:
+			quitarRol(rs)
+		case 6:
+			verRolesUsuario(rs)
+		case 7:
+			fmt.Println("Saliendo...")
+			return
+		}
+	}
+
+}
+
+func listarRoles(rs *roles.RoleStore) {
+	defer ui.Pause("Pulsa Enter para continuar...")
+	list, err := rs.ListRoles()
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	if len(list) == 0 {
+		fmt.Println("No hay roles.")
+		return
+	}
+	for _, r := range list {
+		fmt.Printf("  - %s\n", r.Name)
+	}
+}
+
+func crearRol(rs *roles.RoleStore) {
+	defer ui.Pause("Pulsa Enter para continuar...")
+	nombre := ui.ReadInput("Nombre del rol: ")
+	if err := rs.CreateRole(nombre); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("Rol '%s' creado.\n", nombre)
+}
+
+func eliminarRol(rs *roles.RoleStore) {
+	defer ui.Pause("Pulsa Enter para continuar...")
+	nombre := ui.ReadInput("Nombre del rol a eliminar: ")
+	if err := rs.DeleteRole(nombre); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("Rol '%s' eliminado.\n", nombre)
+}
+
+func asignarRol(rs *roles.RoleStore) {
+	defer ui.Pause("Pulsa Enter para continuar...")
+	usuario := ui.ReadInput("Nombre de usuario: ")
+	rol := ui.ReadInput("Rol a asignar: ")
+	if err := rs.AssignRole(usuario, rol); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("Rol '%s' asignado a '%s'.\n", rol, usuario)
+}
+
+func quitarRol(rs *roles.RoleStore) {
+	defer ui.Pause("Pulsa Enter para continuar...")
+	usuario := ui.ReadInput("Nombre de usuario: ")
+	rol := ui.ReadInput("Rol a quitar: ")
+	if err := rs.RemoveRole(usuario, rol); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("Rol '%s' quitado a '%s'.\n", rol, usuario)
+}
+
+func verRolesUsuario(rs *roles.RoleStore) {
+	defer ui.Pause("Pulsa Enter para continuar...")
+	usuario := ui.ReadInput("Nombre de usuario: ")
+	list, err := rs.GetUserRoles(usuario)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	if len(list) == 0 {
+		fmt.Printf("'%s' no tiene roles asignados.\n", usuario)
+		return
+	}
+	fmt.Printf("Roles de '%s':\n", usuario)
+	for _, r := range list {
+		fmt.Printf("  - %s\n", r)
+	}
+}

--- a/pkg/admin/main.go
+++ b/pkg/admin/main.go
@@ -12,12 +12,12 @@ const rolesDBPath = "data/roles.db"
 func main() {
 	if err := os.MkdirAll("data", 0755); err != nil {
 		fmt.Printf("Error creando directorio data : %v\n", err)
-		return
+		os.Exit(1)
 	}
 	rs, err := roles.NewRoleStore(rolesDBPath, false)
 	if err != nil {
 		fmt.Printf("Error abriendo roles.db: %v\n", err)
-		return
+		os.Exit(1)
 	}
 	defer rs.Close()
 
@@ -72,7 +72,7 @@ func listarRoles(rs *roles.RoleStore) {
 
 func crearRol(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	nombre := ui.ReadInput("Nombre del rol ")
+	nombre := ui.ReadInput("Nombre del rol")
 	if err := rs.CreateRole(nombre); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -82,7 +82,7 @@ func crearRol(rs *roles.RoleStore) {
 
 func eliminarRol(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	nombre := ui.ReadInput("Nombre del rol a eliminar ")
+	nombre := ui.ReadInput("Nombre del rol a eliminar")
 	if err := rs.DeleteRole(nombre); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -92,8 +92,8 @@ func eliminarRol(rs *roles.RoleStore) {
 
 func asignarRol(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	usuario := ui.ReadInput("Nombre de usuario ")
-	rol := ui.ReadInput("Rol a asignar ")
+	usuario := ui.ReadInput("Nombre de usuario")
+	rol := ui.ReadInput("Rol a asignar")
 	if err := rs.AssignRole(usuario, rol); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -103,8 +103,8 @@ func asignarRol(rs *roles.RoleStore) {
 
 func quitarRol(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	usuario := ui.ReadInput("Nombre de usuario ")
-	rol := ui.ReadInput("Rol a quitar ")
+	usuario := ui.ReadInput("Nombre de usuario")
+	rol := ui.ReadInput("Rol a quitar")
 	if err := rs.RemoveRole(usuario, rol); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -114,7 +114,7 @@ func quitarRol(rs *roles.RoleStore) {
 
 func verRolesUsuario(rs *roles.RoleStore) {
 	defer ui.Pause("Pulsa Enter para continuar...")
-	usuario := ui.ReadInput("Nombre de usuario ")
+	usuario := ui.ReadInput("Nombre de usuario")
 	list, err := rs.GetUserRoles(usuario)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -3,6 +3,7 @@ package roles
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	bolt "go.etcd.io/bbolt"
@@ -147,4 +148,95 @@ func (rs *RoleStore) RoleExists(name string) (bool, error) {
 		return nil
 	})
 	return exists, err
+}
+
+// Funcion helper
+
+func getUserRoles(tx *bolt.Tx, username string) (UserRoles, error) {
+	b := tx.Bucket([]byte(bucketUserRoles))
+	if b == nil {
+		return UserRoles{}, fmt.Errorf("bucket de user_roles no encontrado")
+	}
+	data := b.Get([]byte(username))
+	if data == nil {
+		return UserRoles{Username: username, Roles: []string{}}, nil
+	}
+	var ur UserRoles
+	if err := json.Unmarshal(data, &ur); err != nil {
+		return UserRoles{}, err
+	}
+	return ur, nil
+}
+
+// Funciones para administrador
+
+func (rs *RoleStore) AssignRole(username, role string) error {
+	return rs.db.Update(func(tx *bolt.Tx) error {
+		br := tx.Bucket([]byte(bucketRoles))
+		if br == nil {
+			return fmt.Errorf("bucket de roles no encontrado")
+		}
+		if br.Get([]byte(role)) == nil {
+			return fmt.Errorf("el rol '%s' no existe", role)
+		}
+
+		ur, err := getUserRoles(tx, username)
+		if err != nil {
+			return err
+		}
+
+		if slices.Contains(ur.Roles, role) {
+			return fmt.Errorf("el usuario '%s' ya tiene el rol '%s'", username, role)
+		}
+
+		ur.Roles = append(ur.Roles, role)
+
+		data, err := json.Marshal(ur)
+		if err != nil {
+			return err
+		}
+		b := tx.Bucket([]byte(bucketUserRoles))
+		if b == nil {
+			return fmt.Errorf("bucket de user_roles no encontrado")
+		}
+		return b.Put([]byte(username), data)
+	})
+}
+
+func (rs *RoleStore) RemoveRole(username, role string) error {
+	return rs.db.Update(func(tx *bolt.Tx) error {
+		ur, err := getUserRoles(tx, username)
+		if err != nil {
+			return err
+		}
+
+		i := slices.Index(ur.Roles, role)
+		if i == -1 {
+			return fmt.Errorf("el usuario '%s' no tiene el rol '%s'", username, role)
+		}
+		ur.Roles = slices.Delete(ur.Roles, i, i+1)
+
+		data, err := json.Marshal(ur)
+		if err != nil {
+			return err
+		}
+		b := tx.Bucket([]byte(bucketUserRoles))
+		if b == nil {
+			return fmt.Errorf("bucket de user_roles no encontrado")
+		}
+		return b.Put([]byte(username), data)
+	})
+}
+
+func (rs *RoleStore) GetUserRoles(username string) ([]string, error) {
+	var roles []string
+	err := rs.db.View(func(tx *bolt.Tx) error {
+		ur, err := getUserRoles(tx, username)
+		if err != nil {
+			return err
+		}
+		roles = ur.Roles
+		return nil
+	})
+	return roles, err
 }

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -117,25 +117,25 @@ func (rs *RoleStore) DeleteRole(name string) error {
 		}
 
 		bu := tx.Bucket([]byte(bucketUserRoles))
-		if bu != nil {
-			bu.ForEach(func(k, v []byte) error {
-				var ur UserRoles
-				if err := json.Unmarshal(v, &ur); err != nil {
-					return err
-				}
-				i := slices.Index(ur.Roles, name)
-				if i == -1 {
-					return nil
-				}
-				ur.Roles = slices.Delete(ur.Roles, i, i+1)
-				data, err := json.Marshal(ur)
-				if err != nil {
-					return err
-				}
-				return bu.Put(k, data)
-			})
+		if bu == nil {
+			return fmt.Errorf("bucket de user_roles no encontrado")
 		}
-		return nil
+		return bu.ForEach(func(k, v []byte) error {
+			var ur UserRoles
+			if err := json.Unmarshal(v, &ur); err != nil {
+				return err
+			}
+			i := slices.Index(ur.Roles, name)
+			if i == -1 {
+				return nil
+			}
+			ur.Roles = slices.Delete(ur.Roles, i, i+1)
+			data, err := json.Marshal(ur)
+			if err != nil {
+				return err
+			}
+			return bu.Put(k, data)
+		})
 	})
 }
 
@@ -188,6 +188,7 @@ func getUserRoles(tx *bolt.Tx, username string) (UserRoles, error) {
 	if err := json.Unmarshal(data, &ur); err != nil {
 		return UserRoles{}, err
 	}
+	ur.Username = username
 	return ur, nil
 }
 

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -112,7 +112,30 @@ func (rs *RoleStore) DeleteRole(name string) error {
 		if b.Get([]byte(name)) == nil {
 			return fmt.Errorf("el rol '%s' no existe", name)
 		}
-		return b.Delete([]byte(name))
+		if err := b.Delete([]byte(name)); err != nil {
+			return err
+		}
+
+		bu := tx.Bucket([]byte(bucketUserRoles))
+		if bu != nil {
+			bu.ForEach(func(k, v []byte) error {
+				var ur UserRoles
+				if err := json.Unmarshal(v, &ur); err != nil {
+					return err
+				}
+				i := slices.Index(ur.Roles, name)
+				if i == -1 {
+					return nil
+				}
+				ur.Roles = slices.Delete(ur.Roles, i, i+1)
+				data, err := json.Marshal(ur)
+				if err != nil {
+					return err
+				}
+				return bu.Put(k, data)
+			})
+		}
+		return nil
 	})
 }
 

--- a/pkg/roles/roles_test.go
+++ b/pkg/roles/roles_test.go
@@ -2,6 +2,7 @@ package roles
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -158,5 +159,79 @@ func TestRoleStore_PersistsOnDisk(t *testing.T) {
 		if !exists {
 			t.Fatal("el rol 'moderator' debería persistir tras cerrar y reabrir la store")
 		}
+	}
+}
+
+func TestRoleStore_AssignRole(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.AssignRole("carlos", DefaultRole); err != nil {
+		t.Fatalf("AssignRole falló: %v", err)
+	}
+
+	roles, err := rs.GetUserRoles("carlos")
+	if err != nil {
+		t.Fatalf("GetUserRoles falló: %v", err)
+	}
+	if !slices.Contains(roles, DefaultRole) {
+		t.Fatalf("se esperaba el rol %q asignado", DefaultRole)
+	}
+}
+
+func TestRoleStore_AssignRoleNotFound(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.AssignRole("carlos", "noexiste"); err == nil {
+		t.Fatal("se esperaba error al asignar un rol inexistente")
+	}
+}
+
+func TestRoleStore_AssignRoleDuplicate(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.AssignRole("carlos", DefaultRole); err != nil {
+		t.Fatalf("primera AssignRole falló: %v", err)
+	}
+	if err := rs.AssignRole("carlos", DefaultRole); err == nil {
+		t.Fatal("se esperaba error al asignar un rol duplicado")
+	}
+}
+
+func TestRoleStore_RemoveRole(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.AssignRole("carlos", DefaultRole); err != nil {
+		t.Fatalf("AssignRole falló: %v", err)
+	}
+	if err := rs.RemoveRole("carlos", DefaultRole); err != nil {
+		t.Fatalf("RemoveRole falló: %v", err)
+	}
+
+	roles, err := rs.GetUserRoles("carlos")
+	if err != nil {
+		t.Fatalf("GetUserRoles falló: %v", err)
+	}
+	if slices.Contains(roles, DefaultRole) {
+		t.Fatalf("el rol %q no debería estar tras eliminarlo", DefaultRole)
+	}
+}
+
+func TestRoleStore_RemoveRoleNotAssigned(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.RemoveRole("carlos", DefaultRole); err == nil {
+		t.Fatal("se esperaba error al quitar un rol no asignado")
+	}
+}
+
+func TestRoleStore_GetUserRolesEmpty(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	roles, err := rs.GetUserRoles("carlos")
+	if err != nil {
+		t.Fatalf("GetUserRoles falló: %v", err)
+	}
+	if len(roles) != 0 {
+		t.Fatalf("se esperaba slice vacío para usuario sin roles, obtenido: %v", roles)
 	}
 }

--- a/pkg/roles/roles_test.go
+++ b/pkg/roles/roles_test.go
@@ -235,3 +235,58 @@ func TestRoleStore_GetUserRolesEmpty(t *testing.T) {
 		t.Fatalf("se esperaba slice vacío para usuario sin roles, obtenido: %v", roles)
 	}
 }
+
+func TestRoleStore_UserRolesPersistsOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "roles.db")
+
+	{
+		rs, err := NewRoleStore(path, false)
+		if err != nil {
+			t.Fatalf("open falló: %v", err)
+		}
+		if err := rs.AssignRole("carlos", DefaultRole); err != nil {
+			_ = rs.Close()
+			t.Fatalf("AssignRole falló: %v", err)
+		}
+		_ = rs.Close()
+	}
+
+	{
+		rs, err := NewRoleStore(path, false)
+		if err != nil {
+			t.Fatalf("re-open falló: %v", err)
+		}
+		defer rs.Close()
+
+		roles, err := rs.GetUserRoles("carlos")
+		if err != nil {
+			t.Fatalf("GetUserRoles tras re-open falló: %v", err)
+		}
+		if !slices.Contains(roles, DefaultRole) {
+			t.Fatalf("el rol %q debería persistir tras cerrar y reabrir la store", DefaultRole)
+		}
+	}
+}
+
+func TestRoleStore_DeleteRoleCleansUserRoles(t *testing.T) {
+	rs := newTestRoleStore(t)
+
+	if err := rs.CreateRole("moderator"); err != nil {
+		t.Fatalf("CreateRole falló: %v", err)
+	}
+	if err := rs.AssignRole("carlos", "moderator"); err != nil {
+		t.Fatalf("AssignRole falló: %v", err)
+	}
+	if err := rs.DeleteRole("moderator"); err != nil {
+		t.Fatalf("DeleteRole falló: %v", err)
+	}
+
+	roles, err := rs.GetUserRoles("carlos")
+	if err != nil {
+		t.Fatalf("GetUserRoles falló: %v", err)
+	}
+	if slices.Contains(roles, "moderator") {
+		t.Fatal("el rol 'moderator' no debería aparecer en user_roles tras ser eliminado")
+	}
+}


### PR DESCRIPTION
## Referencias
Closes #24 

## Descripción
Añade funciones de asignación de roles a usuarios en `pkg/roles/roles.go` (`AssignRole`, `RemoveRole`, `GetUserRoles`) con sus tests correspondientes, y un CLI interactivo en `pkg/admin/main.go` que permite gestionar roles y asignaciones directamente sobre `roles.db` sin necesidad de que el servidor esté corriendo.

## Tipo de cambio

- [X] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Seguridad
- [ ] Refactor

## Checklist

- [X] El servidor arranca sin errores (`go run main.go`)
- [X] He probado el flujo completo (registro → login → operación → logout)
- [X] No hay contraseñas ni secretos hardcodeados

## Revisión

### Revisores
@mjtf3 

## Checklist de revisión

* [x] El código compila sin errores (`go build ./...`)
* [x] Los tests pasan (`go test ./...`)
* [x] No hay contraseñas ni secretos hardcodeados
* [x] Los errores se manejan correctamente (no hay `_` ignorando errores importantes)
* [x] Las funciones nuevas son coherentes con el estilo del resto del proyecto
* [x] No se exponen endpoints innecesarios
* [x] He probado el flujo manualmente