### PR TITLE
29 flujo de autenticacion con firma digital

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -15,6 +15,11 @@ const (
 	ActionLoginTOTP   = "loginTOTP"
 	ActionTOTPDisable = "totpDisable"
 
+	// private and public key
+	ActionKeySetup   = "key_setup"
+	ActionKeyDisable = "key_disable"
+	ActionLoginKey   = "login_key"
+
 	// File and folder management actions
 	ActionCreateFile = "createFile"
 	ActionDeleteFile = "deleteFile"
@@ -35,6 +40,8 @@ type Request struct {
 	TOTPCode       string `json:"totp_code,omitempty"`
 	TempToken      string `json:"temp_token,omitempty"`
 	ForceNewSecret bool   `json:"force_new_secret,omitempty"`
+	PublicKey      []byte `json:"public_key,omitempty"`
+	Signature      []byte `json:"signature,omitempty"`
 }
 
 type Response struct {
@@ -48,4 +55,7 @@ type Response struct {
 	TempToken      string   `json:"temp_token,omitempty"`
 	OTPAuthURI     string   `json:"otpauth_uri,omitempty"`
 	TOTPEnabled    bool     `json:"totp_enabled,omitempty"`
+	Challenge      []byte   `json:"challenge,omitempty"`
+	KeyAuthEnabled bool     `json:"key_auth_enabled,omitempty"`
+	RequiresKey    bool     `json:"requires_key,omitempty"`
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -16,9 +16,9 @@ const (
 	ActionTOTPDisable = "totpDisable"
 
 	// private and public key
-	ActionKeySetup   = "key_setup"
-	ActionKeyDisable = "key_disable"
-	ActionLoginKey   = "login_key"
+	ActionKeySetup   = "keySetup"
+	ActionKeyDisable = "keyDisable"
+	ActionLoginKey   = "loginKey"
 
 	// File and folder management actions
 	ActionCreateFile = "createFile"

--- a/pkg/server/keys.go
+++ b/pkg/server/keys.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/ed25519"
 	"encoding/json"
 	"sprout/pkg/api"
 	"sprout/pkg/utils"
@@ -46,7 +47,7 @@ func (s *server) keySetup(req api.Request) api.Response {
 	if !s.isTokenValid(req.Username, req.Token) {
 		return api.Response{Success: false, Message: "Token invalido o sesion expirada", SessionExpired: true}
 	}
-	if len(req.PublicKey) == 0 {
+	if len(req.PublicKey) != ed25519.PublicKeySize {
 		return api.Response{Success: false, Message: "Clave publica no proporcionada"}
 	}
 	kd := keyAuthData{Enabled: true, PublicKey: req.PublicKey}
@@ -88,12 +89,16 @@ func (s *server) loginKey(req api.Request) api.Response {
 
 	kd, err := s.getKeyAuthData(pending.Username)
 	if err != nil || !kd.Enabled {
-		return api.Response{Success: false, Message: "Firma invalida"}
+		return api.Response{Success: false, Message: "El usuario no tiene autenticacion por clave activa"}
 	}
 
 	s.mu.Lock()
 	delete(s.pendingKey, req.TempToken)
 	s.mu.Unlock()
+
+	if !utils.VerifySignature(kd.PublicKey, pending.Challenge, req.Signature) {
+		return api.Response{Success: false, Message: "Firma invalida"}
+	}
 
 	token, err := utils.NewRandomToken(lengthToken)
 	if err != nil {

--- a/pkg/server/keys.go
+++ b/pkg/server/keys.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"encoding/json"
+	"sprout/pkg/api"
+	"sprout/pkg/utils"
+	"time"
+)
+
+type keyAuthData struct {
+	Enabled   bool   `json:"enabled"`
+	PublicKey []byte `json:"public_key"`
+}
+
+type pendingKeyLogin struct {
+	Username  string
+	Challenge []byte
+	ExpiresAt time.Time
+}
+
+func (s *server) getKeyAuthData(username string) (keyAuthData, error) {
+	data, err := s.db.Get("keys", []byte(username))
+	if err != nil {
+		return keyAuthData{}, err
+	}
+
+	var td keyAuthData
+	if err := json.Unmarshal(data, &td); err != nil {
+		return keyAuthData{}, err
+	}
+
+	return td, nil
+}
+func (s *server) saveKeyAuthData(username string, td keyAuthData) error {
+	data, err := json.Marshal(td)
+	if err != nil {
+		return err
+	}
+
+	return s.db.Put("keys", []byte(username), data)
+}
+
+// HANDLERS
+
+func (s *server) keySetup(req api.Request) api.Response {
+	if !s.isTokenValid(req.Username, req.Token) {
+		return api.Response{Success: false, Message: "Token invalido o sesion expirada", SessionExpired: true}
+	}
+	if len(req.PublicKey) == 0 {
+		return api.Response{Success: false, Message: "Clave publica no proporcionada"}
+	}
+	kd := keyAuthData{Enabled: true, PublicKey: req.PublicKey}
+	if err := s.saveKeyAuthData(req.Username, kd); err != nil {
+		return api.Response{Success: false, Message: "Error al guardar la clave publica"}
+	}
+	return api.Response{Success: true, Message: "Autenticacion por clave activada"}
+}
+
+func (s *server) keyDisable(req api.Request) api.Response {
+	if !s.isTokenValid(req.Username, req.Token) {
+		return api.Response{Success: false, Message: "Token invalido o sesion expirada", SessionExpired: true}
+	}
+
+	kd, err := s.getKeyAuthData(req.Username)
+	if err != nil {
+		return api.Response{Success: false, Message: "No tienes autenticacion por clave activa"}
+	}
+	kd.Enabled = false
+	kd.PublicKey = nil
+	if err := s.saveKeyAuthData(req.Username, kd); err != nil {
+		return api.Response{Success: false, Message: "Error al desactivar la clave"}
+	}
+	return api.Response{Success: true, Message: "Autenticacion por clave desactivada"}
+}
+
+func (s *server) loginKey(req api.Request) api.Response {
+	s.mu.Lock()
+	pending, ok := s.pendingKey[req.TempToken]
+	if ok && time.Now().After(pending.ExpiresAt) {
+		delete(s.pendingKey, req.TempToken)
+		ok = false
+	}
+	s.mu.Unlock()
+
+	if !ok {
+		return api.Response{Success: false, Message: "Token temporal invalido"}
+	}
+
+	kd, err := s.getKeyAuthData(pending.Username)
+	if err != nil || !kd.Enabled {
+		return api.Response{Success: false, Message: "Firma invalida"}
+	}
+
+	s.mu.Lock()
+	delete(s.pendingKey, req.TempToken)
+	s.mu.Unlock()
+
+	token, err := utils.NewRandomToken(lengthToken)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al crear sesion"}
+	}
+
+	sess := session{
+		Token:     token,
+		ExpiresAt: time.Now().Add(sessionDuration),
+	}
+
+	data, err := json.Marshal(sess)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al serializar sesion"}
+	}
+	if err := s.db.Put("sessions", []byte(pending.Username), data); err != nil {
+		return api.Response{Success: false, Message: "Error al guardar sesion"}
+	}
+
+	return api.Response{Success: true, Message: "Login completo", Token: token, KeyAuthEnabled: true}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,6 +31,7 @@ type server struct {
 	loginAttempts map[string]*loginAttempt
 	pendingTOTP   map[string]pendingTOTPLogin // No le pongo el * porque no lo modifico una vez añadido
 	sessionKeys   map[string][]byte
+	pendingKey    map[string]pendingKeyLogin
 }
 
 type session struct {
@@ -64,6 +65,7 @@ func Run() error {
 		loginAttempts: make(map[string]*loginAttempt),
 		pendingTOTP:   make(map[string]pendingTOTPLogin),
 		sessionKeys:   make(map[string][]byte),
+		pendingKey:    make(map[string]pendingKeyLogin),
 	}
 
 	// Al terminar, cerramos la base de datos
@@ -152,6 +154,13 @@ func (s *server) apiHandler(w http.ResponseWriter, r *http.Request) {
 		res = s.tOTPConfirm(req)
 	case api.ActionTOTPDisable:
 		res = s.totpDisable(req)
+	// Public private key
+	case api.ActionKeySetup:
+		res = s.keySetup(req)
+	case api.ActionKeyDisable:
+		res = s.keyDisable(req)
+	case api.ActionLoginKey:
+		res = s.loginKey(req)
 	default:
 		res = api.Response{Success: false, Message: "Accion desconocida"}
 	}
@@ -276,6 +285,27 @@ func (s *server) loginUser(req api.Request) api.Response {
 			RequiresTOTP: true,
 			TempToken:    tempToken,
 		}
+	}
+
+	// Compruebo si tiene public private key
+	kd, err := s.getKeyAuthData(req.Username)
+	if err == nil && kd.Enabled {
+		challenge, err := utils.NewRandomToken(32)
+		if err != nil {
+			return api.Response{Success: false, Message: "Error al generar challenge"}
+		}
+		tempToken, err := utils.NewRandomToken(lengthToken)
+		if err != nil {
+			return api.Response{Success: false, Message: "Error al generar token temporal"}
+		}
+		s.mu.Lock()
+		s.pendingKey[tempToken] = pendingKeyLogin{
+			Username:  req.Username,
+			Challenge: []byte(challenge),
+			ExpiresAt: time.Now().Add(temporalTokenDuration),
+		}
+		s.mu.Unlock()
+		return api.Response{Success: false, RequiresKey: true, TempToken: tempToken, Challenge: []byte(challenge)}
 	}
 
 	//Sin TOTP - creo la sesion

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -305,10 +305,11 @@ func (s *server) loginUser(req api.Request) api.Response {
 			ExpiresAt: time.Now().Add(temporalTokenDuration),
 		}
 		s.mu.Unlock()
-		return api.Response{Success: false, RequiresKey: true, TempToken: tempToken, Challenge: []byte(challenge)}
+		s.storeSessionKey(req.Username, dek)
+		return api.Response{Success: true, RequiresKey: true, TempToken: tempToken, Challenge: []byte(challenge)}
 	}
 
-	//Sin TOTP - creo la sesion
+	//Sin TOTP ni clave publica - creo la sesion
 	// Generamos un nuevo token, lo guardamos en 'sessions'
 	token, err := utils.NewRandomToken(lengthToken)
 	if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 
 	"sprout/pkg/api"
 	"sprout/pkg/store"
+	"sprout/pkg/utils"
 )
 
 func newTestTLSServer(t *testing.T) (*httptest.Server, string, string) {
@@ -37,6 +39,8 @@ func newTestTLSServer(t *testing.T) (*httptest.Server, string, string) {
 		db:            db,
 		loginAttempts: make(map[string]*loginAttempt),
 		sessionKeys:   make(map[string][]byte),
+		pendingTOTP:   make(map[string]pendingTOTPLogin),
+		pendingKey:    make(map[string]pendingKeyLogin),
 	}
 
 	t.Cleanup(func() { _ = db.Close() })
@@ -236,5 +240,163 @@ func TestServer_DataStoredEncryptedAtRest(t *testing.T) {
 	})
 	if !readRes.Success || readRes.Data != "secreto-en-fichero" {
 		t.Fatalf("readFile fallo: success=%v msg=%q data=%q", readRes.Success, readRes.Message, readRes.Data)
+	}
+}
+func TestServer_KeyAuthSetupAndLogin(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	pub, priv, err := utils.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair falló: %v", err)
+	}
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register falló: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login falló: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:    api.ActionKeySetup,
+		Username:  "alice",
+		Token:     r.Token,
+		PublicKey: pub,
+	})
+	if !r.Success {
+		t.Fatalf("keySetup falló: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success || !r.RequiresKey || r.TempToken == "" || len(r.Challenge) == 0 {
+		t.Fatalf("login debería devolver RequiresKey: success=%v requires_key=%v msg=%q", r.Success, r.RequiresKey, r.Message)
+	}
+
+	signature := ed25519.Sign(priv, r.Challenge)
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:    api.ActionLoginKey,
+		TempToken: r.TempToken,
+		Signature: signature,
+	})
+	if !r.Success || r.Token == "" {
+		t.Fatalf("loginKey falló: success=%v msg=%q token=%q", r.Success, r.Message, r.Token)
+	}
+}
+
+func TestServer_KeyAuthInvalidSignature(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	pub, _, err := utils.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair falló: %v", err)
+	}
+	_, wrongPriv, err := utils.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair (2) falló: %v", err)
+	}
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register falló: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login falló: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:    api.ActionKeySetup,
+		Username:  "alice",
+		Token:     r.Token,
+		PublicKey: pub,
+	})
+	if !r.Success {
+		t.Fatalf("keySetup falló: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.RequiresKey {
+		t.Fatalf("login debería devolver RequiresKey")
+	}
+
+	wrongSig := ed25519.Sign(wrongPriv, r.Challenge)
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:    api.ActionLoginKey,
+		TempToken: r.TempToken,
+		Signature: wrongSig,
+	})
+	if r.Success {
+		t.Fatal("loginKey debería fallar con firma incorrecta")
+	}
+}
+
+func TestServer_KeyAuthInvalidPublicKeySize(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register falló: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login falló: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:    api.ActionKeySetup,
+		Username:  "alice",
+		Token:     r.Token,
+		PublicKey: []byte("clave-corta"),
+	})
+	if r.Success {
+		t.Fatal("keySetup debería fallar con clave pública de tamaño incorrecto")
 	}
 }

--- a/pkg/utils/keys.go
+++ b/pkg/utils/keys.go
@@ -30,6 +30,10 @@ func keyPath(username string) string {
 	return filepath.Join("data", "keys", hex.EncodeToString(hash[:])+".key")
 }
 
+func VerifySignature(publicKey ed25519.PublicKey, message, signature []byte) bool {
+	return ed25519.Verify(publicKey, message, signature)
+}
+
 func GenerateKeyPair() (ed25519.PublicKey, ed25519.PrivateKey, error) {
 	pk, sk, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/pkg/utils/keys_test.go
+++ b/pkg/utils/keys_test.go
@@ -87,3 +87,62 @@ func TestDecryptCorruptFile(t *testing.T) {
 		t.Fatal("debería haber fallado con archivo corrupto")
 	}
 }
+func TestVerifySignature_Valid(t *testing.T) {
+	pub, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair falló: %v", err)
+	}
+
+	message := []byte("challenge-aleatorio")
+	signature := ed25519.Sign(priv, message)
+
+	if !VerifySignature(pub, message, signature) {
+		t.Fatal("VerifySignature debería devolver true para una firma válida")
+	}
+}
+
+func TestVerifySignature_WrongMessage(t *testing.T) {
+	pub, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair falló: %v", err)
+	}
+
+	signature := ed25519.Sign(priv, []byte("mensaje original"))
+
+	if VerifySignature(pub, []byte("mensaje modificado"), signature) {
+		t.Fatal("VerifySignature debería devolver false para mensaje modificado")
+	}
+}
+
+func TestVerifySignature_WrongKey(t *testing.T) {
+	_, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair falló: %v", err)
+	}
+	otherPub, _, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair (2) falló: %v", err)
+	}
+
+	message := []byte("challenge-aleatorio")
+	signature := ed25519.Sign(priv, message)
+
+	if VerifySignature(otherPub, message, signature) {
+		t.Fatal("VerifySignature debería devolver false para clave pública incorrecta")
+	}
+}
+
+func TestVerifySignature_TamperedSignature(t *testing.T) {
+	pub, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair falló: %v", err)
+	}
+
+	message := []byte("challenge-aleatorio")
+	signature := ed25519.Sign(priv, message)
+	signature[0] ^= 0xff
+
+	if VerifySignature(pub, message, signature) {
+		t.Fatal("VerifySignature debería devolver false para firma manipulada")
+	}
+}


### PR DESCRIPTION
## Referencias
Closes #29 
<!-- Añade las referencias de esta PR -->
<!-- Closes #issue -->

## Descripción

Implementa autenticación por clave pública Ed25519 en el servidor mediante un flujo challenge-response: al hacer login el servidor genera un challenge aleatorio y un TempToken si el usuario tiene clave activa, y el cliente deberá firmar el challenge con su clave privada para completar la sesión. Añade los handlers `keySetup`, `keyDisable` y `loginKey` en `pkg/server/keys.go`, integra el flujo en `loginUser`, y expone `VerifySignature` en `pkg/utils/keys.go` con sus tests.

## Tipo de cambio

- [x] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Seguridad
- [ ] Refactor

## Checklist

- [x] El servidor arranca sin errores (`go run main.go`)
- [x] He probado el flujo completo (registro → login → operación → logout)
- [x] No hay contraseñas ni secretos hardcodeados

## Revisión

### Revisores

<!-- Añade los revisores que deben aprobar este PR -->
<!--   - @usuario1 -->
- @msb104 

## Checklist de revisión

- [x] El código compila sin errores (`go build ./...`)
- [x] Los tests pasan (`go test ./...`)
- [x] No hay contraseñas ni secretos hardcodeados
- [x] Los errores se manejan correctamente (no hay `_` ignorando errores importantes)
- [x] Las funciones nuevas son coherentes con el estilo del resto del proyecto
- [x] No se exponen endpoints innecesarios
- [x] He probado el flujo manualmente
