### PR TITLE
49 gestión de metadatos de los ficheros

### DIFF
--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -263,19 +263,24 @@ La carpeta raíz lógica del usuario se trata como metadato virtual:
 - no se persiste en `file_metadata`;
 - se usa para calcular permisos efectivos en rutas hijas.
 
-### Solo se modifican permisos lógicos desde la API
-En esta fase `updateFileMetadata` solo permite cambiar `Permissions`, recibido en `Request.Data`.
+### Permisos lógicos y rol/grupo asociado desde la API
+En esta fase `updateFileMetadata` permite cambiar `Permissions`, recibido en `Request.Data`,
+o asociar un rol/grupo mediante `Request.Role`.
+El cliente separa ambas operaciones en opciones distintas para no mezclar la edición de permisos
+lógicos con la asignación del grupo.
+El rol indicado se valida con `RoleStore.RoleExists` antes de persistirse.
 No se permite modificar `Owner` porque el sistema todavía no implementa compartición real,
 transferencia de propiedad ni redistribución de claves entre usuarios.
 
-Los permisos son lógicos de Sprout, no permisos reales del sistema operativo.
+Los permisos son lógicos de Sprout, no permisos reales del sistema operativo ni un mecanismo de
+compartición por sí mismos.
 Valores iniciales:
 - ficheros: `rw-------`
 - carpetas: `rwx------`
 
 El formato aceptado tiene 9 caracteres y cada tripleta debe respetar el orden `rwx`, permitiendo
-usar `-` para permisos desactivados. Aunque se guarda el string completo, la comprobación efectiva
-actual usa la primera tripleta.
+usar `-` para permisos desactivados. La primera tripleta aplica al propietario (`Owner`), la segunda
+a usuarios que tengan el rol/grupo asociado al metadato (`Role`) y la tercera a otros usuarios.
 
 No se permite modificar permisos de la carpeta raíz del usuario (`.` o ruta normalizada vacía).
 
@@ -295,6 +300,14 @@ con `safePath`.
 Los permisos no son solo informativos: el servidor los consulta antes de ejecutar operaciones.
 La comprobación se hace sobre el árbol de ancestros, empezando por la raíz virtual del usuario.
 Si cualquier elemento del camino no concede el permiso requerido, la operación se rechaza.
+Para cada elemento del árbol, el servidor elige la tripleta efectiva así:
+- si el usuario autenticado es `Owner`, usa la primera tripleta;
+- si no es propietario pero tiene el rol guardado en `Role`, usa la segunda tripleta;
+- en el resto de casos, usa la tercera tripleta.
+
+Esta autorización solo decide si una operación debería permitirse lógicamente. No implementa por sí
+misma descubrimiento de ficheros ajenos, rutas compartidas, ficheros públicos ni redistribución de
+claves para descifrar contenido; esas responsabilidades pertenecen a la funcionalidad de compartición.
 
 Reglas aplicadas:
 - `readFile` requiere permiso `r` en todos los ancestros y en el fichero.

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -183,3 +183,148 @@ al rechazar una petición de admin, y el cliente limpiara `isAdmin` al recibirlo
 a `SessionExpired`). Se descartó: añade complejidad en 6 handlers y en el cliente para un caso
 edge (admin se quita sus propios permisos con sesión activa) que es cosmético, no de seguridad.
 El servidor ya rechaza cada petición individualmente mediante `requireRole`.
+
+---
+
+## Metadatos de ficheros
+
+### Metadatos cifrados en bbolt
+Los metadatos de ficheros y carpetas se almacenan en un namespace propio (`file_metadata`).
+Aunque bbolt no cifra buckets ni claves, los valores se cifran antes de guardarse usando
+AES-GCM y una subclave derivada de la DEK de sesión del usuario.
+
+El valor guardado es un `gcmBlob` con `Version`, `Nonce` y `Ciphertext`.
+El JSON con los campos de metadatos solo existe en claro en memoria, antes de cifrar o después
+de descifrar.
+
+La clave de cifrado de cada entrada usa el contexto del dato:
+`deriveSubkey(dek, "file_metadata:"+normalizedPath, dekLen)`.
+Así, los metadatos quedan integrados en el modelo de cifrado existente y no se introduce
+un secreto nuevo que el usuario tenga que gestionar.
+
+### Claves opacas para no exponer rutas
+No se guardan rutas en claro como claves de bbolt.
+La clave de índice se deriva con `deriveSubkey(dek, "file_metadata_index", dekLen)` y se usa
+como clave HMAC-SHA256 sobre la ruta normalizada.
+
+La clave final del registro combina el usuario con ese HMAC:
+`<username>\x00<hex(HMAC(file_metadata_index, normalized-path))>`.
+
+Esto evita entradas visibles como `alice:docs/nota.txt` dentro de `server.db`.
+Limitaciones aceptadas:
+- los nombres de buckets siguen siendo visibles porque bbolt no los cifra;
+- el nombre de usuario sigue formando parte de la clave;
+- las claves del namespace `file_timestamps` no se han migrado a HMAC y siguen usando
+  `username + "\x00" + reqPath`.
+
+### Separación entre metadatos y detección de cambios externos
+El proyecto ya mantiene timestamps cifrados en `file_timestamps` mediante `storeFileTimestamp`
+y `checkFileTimestamp`.
+Los metadatos tienen sus propios campos `CreatedAt`, `ModifiedAt` y `AccessedAt`, pero no sustituyen
+esa lógica.
+
+Regla decidida:
+- `createFile` sigue guardando el timestamp de control.
+- `modifyFile` valida el timestamp antes de escribir, guarda el nuevo timestamp y actualiza `ModifiedAt`.
+- `readFile` valida el timestamp antes de descifrar y actualiza `AccessedAt` si puede guardar metadatos.
+- `deleteFile` borra el timestamp asociado.
+- `deleteDir` borra los timestamps del árbol mediante prefijo.
+- La detección de modificaciones externas sigue dependiendo de `file_timestamps`.
+
+Los valores de `file_timestamps` están cifrados con una subclave
+`deriveSubkey(baseDEK, "timestamp:"+reqPath, dekLen)`, pero sus claves de bbolt todavía exponen
+usuario y ruta.
+
+### API específica para consulta y actualización
+Se añaden dos acciones:
+`getFileMetadata` y `updateFileMetadata`.
+
+La respuesta puede incluir un `FileMetadata` individual o entradas enriquecidas en listados mediante
+`FileEntries`, manteniendo también `Files []string` para no romper el cliente existente.
+
+Los metadatos incluyen:
+- ruta
+- nombre
+- si es fichero o carpeta
+- tamaño
+- propietario
+- permisos lógicos
+- fechas de creación, modificación y acceso
+- plataforma
+
+### Metadatos creados de forma perezosa
+`ensureFileMetadata` intenta cargar los metadatos existentes y, si no existen, los crea a partir
+del estado actual del fichero o carpeta.
+Esto permite que `getFileMetadata` y `listFiles` reparen entradas antiguas o incompletas generando
+metadatos en el primer acceso.
+
+La carpeta raíz lógica del usuario se trata como metadato virtual:
+- `rootFileMetadata` genera una entrada en memoria con permisos `rwx------`;
+- no se persiste en `file_metadata`;
+- se usa para calcular permisos efectivos en rutas hijas.
+
+### Solo se modifican permisos lógicos desde la API
+En esta fase `updateFileMetadata` solo permite cambiar `Permissions`, recibido en `Request.Data`.
+No se permite modificar `Owner` porque el sistema todavía no implementa compartición real,
+transferencia de propiedad ni redistribución de claves entre usuarios.
+
+Los permisos son lógicos de Sprout, no permisos reales del sistema operativo.
+Valores iniciales:
+- ficheros: `rw-------`
+- carpetas: `rwx------`
+
+El formato aceptado tiene 9 caracteres y cada tripleta debe respetar el orden `rwx`, permitiendo
+usar `-` para permisos desactivados. Aunque se guarda el string completo, la comprobación efectiva
+actual usa la primera tripleta.
+
+No se permite modificar permisos de la carpeta raíz del usuario (`.` o ruta normalizada vacía).
+
+### Metadatos iniciales derivados del sistema y de la sesión
+Al crear ficheros o carpetas se generan metadatos iniciales:
+- `Owner`: usuario autenticado
+- `CreatedAt`: `time.Now().UTC()`
+- `ModifiedAt`: `time.Now().UTC()`
+- `Platform`: `runtime.GOOS`
+- `Name`, `Size` e `IsDir`: derivados de `os.Stat`
+
+La ruta se normaliza antes de calcular claves, cifrar y devolver datos.
+Todas las operaciones requieren sesión válida, DEK disponible mediante `getSessionKey` y ruta validada
+con `safePath`.
+
+### Permisos lógicos aplicados a operaciones de ficheros
+Los permisos no son solo informativos: el servidor los consulta antes de ejecutar operaciones.
+La comprobación se hace sobre el árbol de ancestros, empezando por la raíz virtual del usuario.
+Si cualquier elemento del camino no concede el permiso requerido, la operación se rechaza.
+
+Reglas aplicadas:
+- `readFile` requiere permiso `r` en todos los ancestros y en el fichero.
+- `modifyFile` requiere permiso `w` en todos los ancestros y en el fichero.
+- `deleteFile` requiere permiso `w` en todos los ancestros y en el fichero.
+- `listFiles` requiere permiso `r` en todos los ancestros y en el directorio listado.
+- `createFile` y `createDir` requieren permiso `w` en todos los ancestros y en el directorio padre.
+- `deleteDir` requiere permiso `w` en todos los ancestros y en el directorio eliminado.
+
+`getFileMetadata` y `updateFileMetadata` requieren token válido, ruta segura, fichero o carpeta
+existente y DEK de sesión, pero no aplican una comprobación adicional de permisos lógicos.
+
+### Integración con operaciones de ficheros
+Las operaciones existentes se amplían sin cambiar su contrato principal:
+- `createFile`: crea metadatos iniciales después de escribir y guardar timestamp.
+- `modifyFile`: actualiza contenido, timestamp y `ModifiedAt`.
+- `readFile`: actualiza `AccessedAt`.
+- `deleteFile`: elimina fichero, timestamp y metadatos.
+- `createDir`: crea metadatos iniciales del directorio.
+- `deleteDir`: elimina metadatos y timestamps de la carpeta y de sus hijos antes de `os.RemoveAll`.
+- `listFiles`: devuelve la lista clásica y, además, entradas con metadatos.
+- al borrar el último fichero o carpeta, se elimina la raíz física vacía del usuario.
+
+### Cliente CLI
+El menú de gestión de ficheros incorpora opciones para ver metadatos y modificar permisos lógicos.
+La vista muestra ruta, propietario, permisos, tamaño, fechas, plataforma y si la entrada es fichero
+o carpeta.
+
+El cliente también muestra el árbol de permisos efectivos antes de leer, modificar o borrar, para
+que el usuario vea qué permiso de la ruta puede bloquear la operación.
+
+Si el servidor devuelve un error de timestamp en operaciones de lectura o modificación, el cliente
+reutiliza el flujo existente para ofrecer borrar ficheros fuera de sincronía.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,6 +2,8 @@
 // para la comunicación entre servidor y cliente.
 package api
 
+import "time"
+
 const (
 	ActionRegister   = "register"
 	ActionLogin      = "login"
@@ -30,6 +32,10 @@ const (
 	ActionDeleteDir  = "deleteDir"
 	ActionListFiles  = "listFiles"
 
+	// File metadata management actions
+	ActionGetFileMetadata    = "getFileMetadata"
+	ActionUpdateFileMetadata = "updateFileMetadata"
+
 	// Role management
 	ActionAssignRole   = "assignRole"
 	ActionRemoveRole   = "removeRole"
@@ -55,20 +61,41 @@ type Request struct {
 	TargetUser     string `json:"target_user,omitempty"`
 }
 
+type FileMetadata struct {
+	Path        string    `json:"path"`
+	Name        string    `json:"name"`
+	IsDir       bool      `json:"is_dir"`
+	Size        int64     `json:"size"`
+	Owner       string    `json:"owner"`
+	Permissions string    `json:"permissions"`
+	CreatedAt   time.Time `json:"created_at"`
+	ModifiedAt  time.Time `json:"modified_at"`
+	AccessedAt  time.Time `json:"accessed_at,omitempty"`
+	Platform    string    `json:"platform"`
+}
+
+type FileEntry struct {
+	Name     string        `json:"name"`
+	Path     string        `json:"path"`
+	Metadata *FileMetadata `json:"metadata,omitempty"`
+}
+
 type Response struct {
-	Success        bool     `json:"success"`
-	Message        string   `json:"message"`
-	Token          string   `json:"token,omitempty"`
-	Data           string   `json:"data,omitempty"`
-	SessionExpired bool     `json:"session_expired,omitempty"`
-	Files          []string `json:"files,omitempty"`
-	RequiresTOTP   bool     `json:"requires_totp,omitempty"`
-	TempToken      string   `json:"temp_token,omitempty"`
-	OTPAuthURI     string   `json:"otpauth_uri,omitempty"`
-	TOTPEnabled    bool     `json:"totp_enabled,omitempty"`
-	Challenge      []byte   `json:"challenge,omitempty"`
-	KeyAuthEnabled bool     `json:"key_auth_enabled,omitempty"`
-	RequiresKey    bool     `json:"requires_key,omitempty"`
-	Roles          []string `json:"roles,omitempty"`
-	IsAdmin        bool     `json:"is_admin,omitempty"`
+	Success        bool          `json:"success"`
+	Message        string        `json:"message"`
+	Token          string        `json:"token,omitempty"`
+	Data           string        `json:"data,omitempty"`
+	SessionExpired bool          `json:"session_expired,omitempty"`
+	Files          []string      `json:"files,omitempty"`
+	FileMetadata   *FileMetadata `json:"file_metadata,omitempty"`
+	FileEntries    []FileEntry   `json:"file_entries,omitempty"`
+	RequiresTOTP   bool          `json:"requires_totp,omitempty"`
+	TempToken      string        `json:"temp_token,omitempty"`
+	OTPAuthURI     string        `json:"otpauth_uri,omitempty"`
+	TOTPEnabled    bool          `json:"totp_enabled,omitempty"`
+	Challenge      []byte        `json:"challenge,omitempty"`
+	KeyAuthEnabled bool          `json:"key_auth_enabled,omitempty"`
+	RequiresKey    bool          `json:"requires_key,omitempty"`
+	Roles          []string      `json:"roles,omitempty"`
+	IsAdmin        bool          `json:"is_admin,omitempty"`
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -67,6 +67,7 @@ type FileMetadata struct {
 	IsDir       bool      `json:"is_dir"`
 	Size        int64     `json:"size"`
 	Owner       string    `json:"owner"`
+	Role        string    `json:"role,omitempty"`
 	Permissions string    `json:"permissions"`
 	CreatedAt   time.Time `json:"created_at"`
 	ModifiedAt  time.Time `json:"modified_at"`

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -506,6 +506,7 @@ func (c *client) fileManagerMenu() {
 			"Borrar carpeta",
 			"Ver metadatos",
 			"Modificar permisos lógicos",
+			"Modificar rol/grupo",
 			"Volver al menú principal",
 		}
 
@@ -667,7 +668,29 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 10: // Volver al menú principal
+		case 10: // Modificar rol/grupo
+			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
+			if isClientRootPath(path) {
+				fmt.Println("Éxito: false")
+				fmt.Println("Mensaje: no se puede modificar la carpeta raíz del usuario")
+				break
+			}
+			role := ui.ReadInput("Introduce el rol/grupo asociado")
+			res := c.sendRequest(api.Request{
+				Action:   api.ActionUpdateFileMetadata,
+				Username: c.currentUser,
+				Token:    c.authToken,
+				Path:     path,
+				Role:     role,
+			})
+			fmt.Println("Éxito:", res.Success)
+			fmt.Println("Mensaje:", res.Message)
+			if res.Success && res.FileMetadata != nil {
+				printFileMetadata(*res.FileMetadata)
+			} else {
+				c.maybeOfferDeleteOutOfSyncFile(path, res)
+			}
+		case 11: // Volver al menú principal
 			return
 		}
 		ui.Pause("Pulsa [Enter] para continuar...")
@@ -822,6 +845,9 @@ func printFileMetadata(meta api.FileMetadata) {
 	fmt.Println("Tipo:", itemType)
 	fmt.Println("Tamaño:", meta.Size)
 	fmt.Println("Propietario:", meta.Owner)
+	if meta.Role != "" {
+		fmt.Println("Rol/grupo:", meta.Role)
+	}
 	fmt.Println("Permisos:", meta.Permissions)
 	fmt.Println("Creado:", meta.CreatedAt.Format(time.RFC3339))
 	fmt.Println("Modificado:", meta.ModifiedAt.Format(time.RFC3339))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -513,6 +513,9 @@ func (c *client) fileManagerMenu() {
 		switch choice {
 		case 1: // Listar directorio
 			path := ui.ReadInput("Introduce el directorio a listar (deja vací­o para la raí­z)")
+			if !c.ensureLogicalPermission(path, true, 'r', "listar el directorio") {
+				break
+			}
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionListFiles,
 				Username: c.currentUser,
@@ -529,6 +532,9 @@ func (c *client) fileManagerMenu() {
 			}
 		case 2: // Crear fichero
 			path := ui.ReadInput("Introduce la ruta/nombre del nuevo fichero")
+			if !c.ensureParentLogicalPermission(path, 'w', "crear el fichero") {
+				break
+			}
 			data := ui.ReadInput("Introduce el contenido del fichero")
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionCreateFile,
@@ -541,6 +547,9 @@ func (c *client) fileManagerMenu() {
 			fmt.Println("Mensaje:", res.Message)
 		case 3: // Borrar fichero
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero a borrar")
+			if !c.ensureLogicalPermission(path, true, 'w', "borrar el fichero") {
+				break
+			}
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionDeleteFile,
 				Username: c.currentUser,
@@ -551,21 +560,7 @@ func (c *client) fileManagerMenu() {
 			fmt.Println("Mensaje:", res.Message)
 		case 4: // Modificar fichero
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero a modificar")
-			metaRes := c.sendRequest(api.Request{
-				Action:   api.ActionGetFileMetadata,
-				Username: c.currentUser,
-				Token:    c.authToken,
-				Path:     path,
-			})
-			if !metaRes.Success {
-				fmt.Println("Éxito:", metaRes.Success)
-				fmt.Println("Mensaje:", metaRes.Message)
-				c.maybeOfferDeleteOutOfSyncFile(path, metaRes)
-				break
-			}
-			if metaRes.FileMetadata == nil || !canWriteLogical(*metaRes.FileMetadata) {
-				fmt.Println("Éxito: false")
-				fmt.Println("Mensaje: permiso denegado para modificar el fichero")
+			if !c.ensureLogicalPermission(path, true, 'w', "modificar el fichero") {
 				break
 			}
 			data := ui.ReadMultiline("Introduce el nuevo contenido del fichero, el contenido actual se sobrescribirá.")
@@ -581,6 +576,9 @@ func (c *client) fileManagerMenu() {
 			c.maybeOfferDeleteOutOfSyncFile(path, res)
 		case 5: // Visualizar fichero
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero a visualizar")
+			if !c.ensureLogicalPermission(path, true, 'r', "visualizar el fichero") {
+				break
+			}
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionReadFile,
 				Username: c.currentUser,
@@ -598,6 +596,14 @@ func (c *client) fileManagerMenu() {
 			}
 		case 6: // Crear carpeta
 			path := ui.ReadInput("Introduce la ruta/nombre de la nueva carpeta")
+			if isClientRootPath(path) {
+				fmt.Println("Éxito: false")
+				fmt.Println("Mensaje: no se puede operar sobre la carpeta raíz del usuario")
+				break
+			}
+			if !c.ensureParentLogicalPermission(path, 'w', "crear la carpeta") {
+				break
+			}
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionCreateDir,
 				Username: c.currentUser,
@@ -608,6 +614,14 @@ func (c *client) fileManagerMenu() {
 			fmt.Println("Mensaje:", res.Message)
 		case 7: // Borrar carpeta
 			path := ui.ReadInput("Introduce la ruta/nombre de la carpeta a borrar")
+			if isClientRootPath(path) {
+				fmt.Println("Éxito: false")
+				fmt.Println("Mensaje: no se puede operar sobre la carpeta raíz del usuario")
+				break
+			}
+			if !c.ensureLogicalPermission(path, true, 'w', "borrar la carpeta") {
+				break
+			}
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionDeleteDir,
 				Username: c.currentUser,
@@ -633,6 +647,11 @@ func (c *client) fileManagerMenu() {
 			}
 		case 9: // Modificar permisos lógicos
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
+			if isClientRootPath(path) {
+				fmt.Println("Éxito: false")
+				fmt.Println("Mensaje: no se puede modificar la carpeta raíz del usuario")
+				break
+			}
 			permissions := ui.ReadInput("Introduce permisos en formato rwx------")
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionUpdateFileMetadata,
@@ -655,8 +674,141 @@ func (c *client) fileManagerMenu() {
 	}
 }
 
-func canWriteLogical(meta api.FileMetadata) bool {
-	return len(meta.Permissions) >= 2 && meta.Permissions[1] == 'w'
+func (c *client) ensureLogicalPermission(path string, includeTarget bool, permission byte, operation string) bool {
+	tree, ok := c.loadClientPermissionTree(path, includeTarget)
+	if !ok {
+		return false
+	}
+	printPermissionTree(tree)
+	if !hasClientPermissionThroughTree(tree, permission) {
+		fmt.Println("Éxito: false")
+		fmt.Println("Mensaje: permiso denegado para " + operation)
+		return false
+	}
+	return true
+}
+
+func (c *client) ensureParentLogicalPermission(path string, permission byte, operation string) bool {
+	parent := parentClientPath(path)
+	tree, ok := c.loadClientPermissionTree(parent, true)
+	if !ok {
+		return false
+	}
+	printPermissionTree(tree)
+	if !hasClientPermissionThroughTree(tree, permission) {
+		fmt.Println("Éxito: false")
+		fmt.Println("Mensaje: permiso denegado para " + operation)
+		return false
+	}
+	return true
+}
+
+func (c *client) loadClientPermissionTree(path string, includeTarget bool) ([]api.FileMetadata, bool) {
+	tree := []api.FileMetadata{{
+		Path:        "",
+		Name:        c.currentUser,
+		IsDir:       true,
+		Owner:       c.currentUser,
+		Permissions: "rwx------",
+	}}
+	prefixes := clientPathPrefixes(path)
+	if !includeTarget && len(prefixes) > 0 {
+		prefixes = prefixes[:len(prefixes)-1]
+	}
+	for _, prefix := range prefixes {
+		res := c.sendRequest(api.Request{
+			Action:   api.ActionGetFileMetadata,
+			Username: c.currentUser,
+			Token:    c.authToken,
+			Path:     prefix,
+		})
+		if !res.Success {
+			fmt.Println("Éxito:", res.Success)
+			fmt.Println("Mensaje:", res.Message)
+			c.maybeOfferDeleteOutOfSyncFile(prefix, res)
+			return nil, false
+		}
+		if res.FileMetadata == nil {
+			fmt.Println("Éxito: false")
+			fmt.Println("Mensaje: respuesta sin metadatos")
+			return nil, false
+		}
+		tree = append(tree, *res.FileMetadata)
+	}
+	return tree, true
+}
+
+func printPermissionTree(tree []api.FileMetadata) {
+	fmt.Println("--- Permisos efectivos ---")
+	for i, meta := range tree {
+		indent := strings.Repeat("  ", i)
+		path := meta.Path
+		if path == "" {
+			path = meta.Name + "/"
+		} else if meta.IsDir {
+			path += "/"
+		}
+		fmt.Printf("%s%s (%s)\n", indent, path, meta.Permissions)
+	}
+	fmt.Println("--------------------------")
+}
+
+func hasClientPermissionThroughTree(tree []api.FileMetadata, permission byte) bool {
+	for _, meta := range tree {
+		if !hasClientLogicalPermission(meta, permission) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasClientLogicalPermission(meta api.FileMetadata, permission byte) bool {
+	if len(meta.Permissions) < 3 {
+		return false
+	}
+	switch permission {
+	case 'r':
+		return meta.Permissions[0] == 'r'
+	case 'w':
+		return meta.Permissions[1] == 'w'
+	case 'x':
+		return meta.Permissions[2] == 'x'
+	default:
+		return false
+	}
+}
+
+func clientPathPrefixes(path string) []string {
+	normalized := normalizeClientPath(path)
+	if normalized == "" {
+		return nil
+	}
+	parts := strings.Split(normalized, "/")
+	prefixes := make([]string, 0, len(parts))
+	for i := range parts {
+		prefixes = append(prefixes, strings.Join(parts[:i+1], "/"))
+	}
+	return prefixes
+}
+
+func parentClientPath(path string) string {
+	normalized := normalizeClientPath(path)
+	if normalized == "" || !strings.Contains(normalized, "/") {
+		return ""
+	}
+	return normalized[:strings.LastIndex(normalized, "/")]
+}
+
+func normalizeClientPath(path string) string {
+	normalized := strings.Trim(strings.ReplaceAll(strings.TrimSpace(path), "\\", "/"), "/")
+	if normalized == "." {
+		return ""
+	}
+	return normalized
+}
+
+func isClientRootPath(path string) bool {
+	return normalizeClientPath(path) == ""
 }
 
 func printFileMetadata(meta api.FileMetadata) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -504,6 +504,8 @@ func (c *client) fileManagerMenu() {
 			"Visualizar fichero",
 			"Crear carpeta",
 			"Borrar carpeta",
+			"Ver metadatos",
+			"Modificar permisos lógicos",
 			"Volver al menú principal",
 		}
 
@@ -549,6 +551,23 @@ func (c *client) fileManagerMenu() {
 			fmt.Println("Mensaje:", res.Message)
 		case 4: // Modificar fichero
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero a modificar")
+			metaRes := c.sendRequest(api.Request{
+				Action:   api.ActionGetFileMetadata,
+				Username: c.currentUser,
+				Token:    c.authToken,
+				Path:     path,
+			})
+			if !metaRes.Success {
+				fmt.Println("Éxito:", metaRes.Success)
+				fmt.Println("Mensaje:", metaRes.Message)
+				c.maybeOfferDeleteOutOfSyncFile(path, metaRes)
+				break
+			}
+			if metaRes.FileMetadata == nil || !canWriteLogical(*metaRes.FileMetadata) {
+				fmt.Println("Éxito: false")
+				fmt.Println("Mensaje: permiso denegado para modificar el fichero")
+				break
+			}
 			data := ui.ReadMultiline("Introduce el nuevo contenido del fichero, el contenido actual se sobrescribirá.")
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionModifyFile,
@@ -597,11 +616,68 @@ func (c *client) fileManagerMenu() {
 			})
 			fmt.Println("Éxito:", res.Success)
 			fmt.Println("Mensaje:", res.Message)
-		case 8: // Volver al menú principal
+		case 8: // Ver metadatos
+			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
+			res := c.sendRequest(api.Request{
+				Action:   api.ActionGetFileMetadata,
+				Username: c.currentUser,
+				Token:    c.authToken,
+				Path:     path,
+			})
+			fmt.Println("Éxito:", res.Success)
+			fmt.Println("Mensaje:", res.Message)
+			if res.Success && res.FileMetadata != nil {
+				printFileMetadata(*res.FileMetadata)
+			} else {
+				c.maybeOfferDeleteOutOfSyncFile(path, res)
+			}
+		case 9: // Modificar permisos lógicos
+			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
+			permissions := ui.ReadInput("Introduce permisos en formato rwx------")
+			res := c.sendRequest(api.Request{
+				Action:   api.ActionUpdateFileMetadata,
+				Username: c.currentUser,
+				Token:    c.authToken,
+				Path:     path,
+				Data:     permissions,
+			})
+			fmt.Println("Éxito:", res.Success)
+			fmt.Println("Mensaje:", res.Message)
+			if res.Success && res.FileMetadata != nil {
+				printFileMetadata(*res.FileMetadata)
+			} else {
+				c.maybeOfferDeleteOutOfSyncFile(path, res)
+			}
+		case 10: // Volver al menú principal
 			return
 		}
 		ui.Pause("Pulsa [Enter] para continuar...")
 	}
+}
+
+func canWriteLogical(meta api.FileMetadata) bool {
+	return len(meta.Permissions) >= 2 && meta.Permissions[1] == 'w'
+}
+
+func printFileMetadata(meta api.FileMetadata) {
+	itemType := "fichero"
+	if meta.IsDir {
+		itemType = "directorio"
+	}
+	fmt.Println("--- Metadatos ---")
+	fmt.Println("Ruta:", meta.Path)
+	fmt.Println("Nombre:", meta.Name)
+	fmt.Println("Tipo:", itemType)
+	fmt.Println("Tamaño:", meta.Size)
+	fmt.Println("Propietario:", meta.Owner)
+	fmt.Println("Permisos:", meta.Permissions)
+	fmt.Println("Creado:", meta.CreatedAt.Format(time.RFC3339))
+	fmt.Println("Modificado:", meta.ModifiedAt.Format(time.RFC3339))
+	if !meta.AccessedAt.IsZero() {
+		fmt.Println("Accedido:", meta.AccessedAt.Format(time.RFC3339))
+	}
+	fmt.Println("Plataforma:", meta.Platform)
+	fmt.Println("-----------------")
 }
 
 func (c *client) manageTOTP() {

--- a/pkg/server/file_metadata.go
+++ b/pkg/server/file_metadata.go
@@ -101,6 +101,10 @@ func decryptFileMetadata(dek []byte, path string, data []byte) (api.FileMetadata
 }
 
 func (s *server) loadFileMetadata(username string, dek []byte, path string, info os.FileInfo) (api.FileMetadata, error) {
+	if normalizedFilePath(path) == "" {
+		_ = s.deleteRootFileMetadata(username, dek)
+		return rootFileMetadata(username), nil
+	}
 	key, err := fileMetadataKey(dek, username, path)
 	if err != nil {
 		return api.FileMetadata{}, err
@@ -119,6 +123,9 @@ func (s *server) loadFileMetadata(username string, dek []byte, path string, info
 
 func (s *server) saveFileMetadata(username string, dek []byte, meta api.FileMetadata) error {
 	meta.Path = normalizedFilePath(meta.Path)
+	if meta.Path == "" {
+		return nil
+	}
 	key, err := fileMetadataKey(dek, username, meta.Path)
 	if err != nil {
 		return err
@@ -131,6 +138,10 @@ func (s *server) saveFileMetadata(username string, dek []byte, meta api.FileMeta
 }
 
 func (s *server) ensureFileMetadata(username string, dek []byte, path string, info os.FileInfo) (api.FileMetadata, error) {
+	if normalizedFilePath(path) == "" {
+		_ = s.deleteRootFileMetadata(username, dek)
+		return rootFileMetadata(username), nil
+	}
 	meta, err := s.loadFileMetadata(username, dek, path, info)
 	if err == nil {
 		return meta, nil
@@ -159,7 +170,24 @@ func (s *server) ensureFileMetadata(username string, dek []byte, path string, in
 }
 
 func (s *server) deleteFileMetadata(username string, dek []byte, path string) error {
+	if normalizedFilePath(path) == "" {
+		return nil
+	}
 	key, err := fileMetadataKey(dek, username, path)
+	if err != nil {
+		return err
+	}
+	if err := s.db.Delete(fileMetadataNamespace, key); err != nil {
+		if errors.Is(err, store.ErrNamespaceNotFound) || errors.Is(err, store.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *server) deleteRootFileMetadata(username string, dek []byte) error {
+	key, err := fileMetadataKey(dek, username, "")
 	if err != nil {
 		return err
 	}
@@ -260,6 +288,78 @@ func parentFilePath(path string) string {
 	return parent
 }
 
+func rootFileMetadata(username string) api.FileMetadata {
+	now := time.Now().UTC()
+	return api.FileMetadata{
+		Path:        "",
+		Name:        username,
+		IsDir:       true,
+		Owner:       username,
+		Permissions: "rwx------",
+		CreatedAt:   now,
+		ModifiedAt:  now,
+		Platform:    runtime.GOOS,
+	}
+}
+
+func pathPrefixes(path string) []string {
+	normalized := normalizedFilePath(path)
+	if normalized == "" {
+		return nil
+	}
+	parts := strings.Split(normalized, "/")
+	prefixes := make([]string, 0, len(parts))
+	for i := range parts {
+		prefixes = append(prefixes, strings.Join(parts[:i+1], "/"))
+	}
+	return prefixes
+}
+
+func (s *server) loadPermissionTree(username string, dek []byte, path string, includeTarget bool) ([]api.FileMetadata, error) {
+	normalized := normalizedFilePath(path)
+	tree := []api.FileMetadata{rootFileMetadata(username)}
+	prefixes := pathPrefixes(normalized)
+	if !includeTarget && len(prefixes) > 0 {
+		prefixes = prefixes[:len(prefixes)-1]
+	}
+	for _, prefix := range prefixes {
+		absPath, err := s.safePath(username, prefix)
+		if err != nil {
+			return nil, err
+		}
+		info, err := os.Stat(absPath)
+		if err != nil {
+			return nil, err
+		}
+		meta, err := s.ensureFileMetadata(username, dek, prefix, info)
+		if err != nil {
+			return nil, err
+		}
+		tree = append(tree, meta)
+	}
+	return tree, nil
+}
+
+func hasPermissionThroughTree(tree []api.FileMetadata, permission byte) bool {
+	for _, meta := range tree {
+		if !hasLogicalPermission(meta, permission) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *server) requirePathPermission(username string, dek []byte, path string, includeTarget bool, permission byte) api.Response {
+	tree, err := s.loadPermissionTree(username, dek, path, includeTarget)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al obtener permisos del arbol"}
+	}
+	if !hasPermissionThroughTree(tree, permission) {
+		return api.Response{Success: false, Message: "Permiso denegado"}
+	}
+	return api.Response{Success: true}
+}
+
 func (s *server) requireFilePermission(username string, dek []byte, path string, info os.FileInfo, permission byte) api.Response {
 	meta, err := s.ensureFileMetadata(username, dek, path, info)
 	if err != nil {
@@ -281,12 +381,6 @@ func (s *server) requireParentDirWrite(username string, dek []byte, childPath st
 	if err != nil || !info.IsDir() {
 		return api.Response{Success: false, Message: "El directorio padre no existe"}
 	}
-	meta, err := s.ensureFileMetadata(username, dek, parentPath, info)
-	if err != nil {
-		return api.Response{Success: false, Message: "Error al obtener metadatos del directorio padre"}
-	}
-	if !hasLogicalPermission(meta, 'w') || !hasLogicalPermission(meta, 'x') {
-		return api.Response{Success: false, Message: "Permiso denegado"}
-	}
-	return api.Response{Success: true, FileMetadata: &meta}
+	_ = info
+	return s.requirePathPermission(username, dek, parentPath, true, 'w')
 }

--- a/pkg/server/file_metadata.go
+++ b/pkg/server/file_metadata.go
@@ -1,0 +1,292 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"sprout/pkg/api"
+	"sprout/pkg/store"
+)
+
+const fileMetadataNamespace = "file_metadata"
+
+func normalizedFilePath(reqPath string) string {
+	cleaned := filepath.Clean(strings.TrimSpace(reqPath))
+	if cleaned == "." {
+		return ""
+	}
+	return filepath.ToSlash(cleaned)
+}
+
+func fileMetadataKey(dek []byte, username, path string) ([]byte, error) {
+	indexKey, err := deriveSubkey(dek, "file_metadata_index", dekLen)
+	if err != nil {
+		return nil, err
+	}
+	mac := hmac.New(sha256.New, indexKey)
+	_, _ = mac.Write([]byte(normalizedFilePath(path)))
+	return []byte(username + "\x00" + hex.EncodeToString(mac.Sum(nil))), nil
+}
+
+func encryptFileMetadata(dek []byte, path string, meta api.FileMetadata) ([]byte, error) {
+	plaintext, err := json.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("no se pudo serializar metadatos: %w", err)
+	}
+
+	key, err := deriveSubkey(dek, "file_metadata:"+normalizedFilePath(path), dekLen)
+	if err != nil {
+		return nil, err
+	}
+
+	ciphertext, nonce, err := encryptWithGCM(key, plaintext)
+	if err != nil {
+		return nil, err
+	}
+
+	blob, err := json.Marshal(gcmBlob{
+		Version:    cryptoVersion,
+		Nonce:      base64.RawStdEncoding.EncodeToString(nonce),
+		Ciphertext: base64.RawStdEncoding.EncodeToString(ciphertext),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("no se pudo serializar metadatos cifrados: %w", err)
+	}
+	return blob, nil
+}
+
+func decryptFileMetadata(dek []byte, path string, data []byte) (api.FileMetadata, error) {
+	var blob gcmBlob
+	if err := json.Unmarshal(data, &blob); err != nil {
+		return api.FileMetadata{}, fmt.Errorf("metadatos cifrados invalidos: %w", err)
+	}
+	if blob.Version != cryptoVersion {
+		return api.FileMetadata{}, fmt.Errorf("version de metadatos no soportada: %d", blob.Version)
+	}
+
+	nonce, err := base64.RawStdEncoding.DecodeString(blob.Nonce)
+	if err != nil {
+		return api.FileMetadata{}, fmt.Errorf("nonce de metadatos invalido: %w", err)
+	}
+	ciphertext, err := base64.RawStdEncoding.DecodeString(blob.Ciphertext)
+	if err != nil {
+		return api.FileMetadata{}, fmt.Errorf("ciphertext de metadatos invalido: %w", err)
+	}
+
+	key, err := deriveSubkey(dek, "file_metadata:"+normalizedFilePath(path), dekLen)
+	if err != nil {
+		return api.FileMetadata{}, err
+	}
+	plaintext, err := decryptWithGCM(key, nonce, ciphertext)
+	if err != nil {
+		return api.FileMetadata{}, err
+	}
+
+	var meta api.FileMetadata
+	if err := json.Unmarshal(plaintext, &meta); err != nil {
+		return api.FileMetadata{}, fmt.Errorf("metadatos invalidos: %w", err)
+	}
+	return meta, nil
+}
+
+func (s *server) loadFileMetadata(username string, dek []byte, path string, info os.FileInfo) (api.FileMetadata, error) {
+	key, err := fileMetadataKey(dek, username, path)
+	if err != nil {
+		return api.FileMetadata{}, err
+	}
+	data, err := s.db.Get(fileMetadataNamespace, key)
+	if err != nil {
+		return api.FileMetadata{}, err
+	}
+
+	meta, err := decryptFileMetadata(dek, path, data)
+	if err != nil {
+		return api.FileMetadata{}, err
+	}
+	return mergeFileMetadata(path, meta, info), nil
+}
+
+func (s *server) saveFileMetadata(username string, dek []byte, meta api.FileMetadata) error {
+	meta.Path = normalizedFilePath(meta.Path)
+	key, err := fileMetadataKey(dek, username, meta.Path)
+	if err != nil {
+		return err
+	}
+	data, err := encryptFileMetadata(dek, meta.Path, meta)
+	if err != nil {
+		return err
+	}
+	return s.db.Put(fileMetadataNamespace, key, data)
+}
+
+func (s *server) ensureFileMetadata(username string, dek []byte, path string, info os.FileInfo) (api.FileMetadata, error) {
+	meta, err := s.loadFileMetadata(username, dek, path, info)
+	if err == nil {
+		return meta, nil
+	}
+	if !errors.Is(err, store.ErrNamespaceNotFound) && !errors.Is(err, store.ErrKeyNotFound) {
+		return api.FileMetadata{}, err
+	}
+
+	now := time.Now().UTC()
+	permissions := "rw-------"
+	if info.IsDir() {
+		permissions = "rwx------"
+	}
+	meta = mergeFileMetadata(path, api.FileMetadata{
+		Path:        normalizedFilePath(path),
+		Owner:       username,
+		Permissions: permissions,
+		CreatedAt:   now,
+		ModifiedAt:  now,
+		Platform:    runtime.GOOS,
+	}, info)
+	if err := s.saveFileMetadata(username, dek, meta); err != nil {
+		return api.FileMetadata{}, err
+	}
+	return meta, nil
+}
+
+func (s *server) deleteFileMetadata(username string, dek []byte, path string) error {
+	key, err := fileMetadataKey(dek, username, path)
+	if err != nil {
+		return err
+	}
+	if err := s.db.Delete(fileMetadataNamespace, key); err != nil {
+		if errors.Is(err, store.ErrNamespaceNotFound) || errors.Is(err, store.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *server) deleteFileMetadataTree(username string, dek []byte, rootAbsPath string) error {
+	baseDir := filepath.Join("data", "files", username)
+	baseDirAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return err
+	}
+
+	return filepath.WalkDir(rootAbsPath, func(path string, _ fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(baseDirAbs, absPath)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			rel = ""
+		}
+		return s.deleteFileMetadata(username, dek, rel)
+	})
+}
+
+func mergeFileMetadata(path string, meta api.FileMetadata, info os.FileInfo) api.FileMetadata {
+	meta.Path = normalizedFilePath(path)
+	meta.Name = info.Name()
+	meta.IsDir = info.IsDir()
+	meta.Size = info.Size()
+	if meta.Owner == "" {
+		meta.Owner = ""
+	}
+	if meta.Platform == "" {
+		meta.Platform = runtime.GOOS
+	}
+	return meta
+}
+
+func validFilePermissions(permissions string) bool {
+	if len(permissions) != 9 {
+		return false
+	}
+	for i, r := range permissions {
+		switch i % 3 {
+		case 0:
+			if r != 'r' && r != '-' {
+				return false
+			}
+		case 1:
+			if r != 'w' && r != '-' {
+				return false
+			}
+		case 2:
+			if r != 'x' && r != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func hasLogicalPermission(meta api.FileMetadata, permission byte) bool {
+	if len(meta.Permissions) < 3 {
+		return false
+	}
+	switch permission {
+	case 'r':
+		return meta.Permissions[0] == 'r'
+	case 'w':
+		return meta.Permissions[1] == 'w'
+	case 'x':
+		return meta.Permissions[2] == 'x'
+	default:
+		return false
+	}
+}
+
+func parentFilePath(path string) string {
+	normalized := normalizedFilePath(path)
+	parent := filepath.ToSlash(filepath.Dir(normalized))
+	if parent == "." {
+		return ""
+	}
+	return parent
+}
+
+func (s *server) requireFilePermission(username string, dek []byte, path string, info os.FileInfo, permission byte) api.Response {
+	meta, err := s.ensureFileMetadata(username, dek, path, info)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al obtener metadatos"}
+	}
+	if !hasLogicalPermission(meta, permission) {
+		return api.Response{Success: false, Message: "Permiso denegado"}
+	}
+	return api.Response{Success: true, FileMetadata: &meta}
+}
+
+func (s *server) requireParentDirWrite(username string, dek []byte, childPath string) api.Response {
+	parentPath := parentFilePath(childPath)
+	parentAbsPath, err := s.safePath(username, parentPath)
+	if err != nil {
+		return api.Response{Success: false, Message: err.Error()}
+	}
+	info, err := os.Stat(parentAbsPath)
+	if err != nil || !info.IsDir() {
+		return api.Response{Success: false, Message: "El directorio padre no existe"}
+	}
+	meta, err := s.ensureFileMetadata(username, dek, parentPath, info)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al obtener metadatos del directorio padre"}
+	}
+	if !hasLogicalPermission(meta, 'w') || !hasLogicalPermission(meta, 'x') {
+		return api.Response{Success: false, Message: "Permiso denegado"}
+	}
+	return api.Response{Success: true, FileMetadata: &meta}
+}

--- a/pkg/server/file_metadata.go
+++ b/pkg/server/file_metadata.go
@@ -264,19 +264,36 @@ func validFilePermissions(permissions string) bool {
 }
 
 func hasLogicalPermission(meta api.FileMetadata, permission byte) bool {
-	if len(meta.Permissions) < 3 {
+	return hasPermissionAt(meta.Permissions, 0, permission)
+}
+
+func hasPermissionAt(permissions string, offset int, permission byte) bool {
+	if len(permissions) != 9 || offset < 0 || offset+2 >= len(permissions) {
 		return false
 	}
 	switch permission {
 	case 'r':
-		return meta.Permissions[0] == 'r'
+		return permissions[offset] == 'r'
 	case 'w':
-		return meta.Permissions[1] == 'w'
+		return permissions[offset+1] == 'w'
 	case 'x':
-		return meta.Permissions[2] == 'x'
+		return permissions[offset+2] == 'x'
 	default:
 		return false
 	}
+}
+
+func (s *server) hasLogicalPermissionForUser(username string, meta api.FileMetadata, permission byte) bool {
+	offset := 6
+	if username == meta.Owner {
+		offset = 0
+	} else if meta.Role != "" {
+		ok, err := s.roles.HasRole(username, meta.Role)
+		if err == nil && ok {
+			offset = 3
+		}
+	}
+	return hasPermissionAt(meta.Permissions, offset, permission)
 }
 
 func parentFilePath(path string) string {
@@ -340,9 +357,9 @@ func (s *server) loadPermissionTree(username string, dek []byte, path string, in
 	return tree, nil
 }
 
-func hasPermissionThroughTree(tree []api.FileMetadata, permission byte) bool {
+func (s *server) hasPermissionThroughTree(username string, tree []api.FileMetadata, permission byte) bool {
 	for _, meta := range tree {
-		if !hasLogicalPermission(meta, permission) {
+		if !s.hasLogicalPermissionForUser(username, meta, permission) {
 			return false
 		}
 	}
@@ -354,7 +371,7 @@ func (s *server) requirePathPermission(username string, dek []byte, path string,
 	if err != nil {
 		return api.Response{Success: false, Message: "Error al obtener permisos del arbol"}
 	}
-	if !hasPermissionThroughTree(tree, permission) {
+	if !s.hasPermissionThroughTree(username, tree, permission) {
 		return api.Response{Success: false, Message: "Permiso denegado"}
 	}
 	return api.Response{Success: true}
@@ -365,7 +382,7 @@ func (s *server) requireFilePermission(username string, dek []byte, path string,
 	if err != nil {
 		return api.Response{Success: false, Message: "Error al obtener metadatos"}
 	}
-	if !hasLogicalPermission(meta, permission) {
+	if !s.hasLogicalPermissionForUser(username, meta, permission) {
 		return api.Response{Success: false, Message: "Permiso denegado"}
 	}
 	return api.Response{Success: true, FileMetadata: &meta}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -530,6 +530,15 @@ func (s *server) safePath(username, reqPath string) (string, error) {
 	return targetPathAbs, nil
 }
 
+func (s *server) removeUserRootIfEmpty(username string) {
+	baseDir := filepath.Join("data", "files", username)
+	entries, err := os.ReadDir(baseDir)
+	if err != nil || len(entries) != 0 {
+		return
+	}
+	_ = os.Remove(baseDir)
+}
+
 func (s *server) createFile(req api.Request) api.Response {
 	if !s.isTokenValid(req.Username, req.Token) {
 		return api.Response{Success: false, Message: "Token invalido o sesion expirada"}
@@ -597,7 +606,7 @@ func (s *server) deleteFile(req api.Request) api.Response {
 		return api.Response{Success: false, Message: "Sesion inconsistente: vuelve a iniciar sesion"}
 	}
 
-	if perm := s.requireFilePermission(req.Username, dek, req.Path, info, 'w'); !perm.Success {
+	if perm := s.requirePathPermission(req.Username, dek, req.Path, true, 'w'); !perm.Success {
 		return perm
 	}
 
@@ -606,6 +615,7 @@ func (s *server) deleteFile(req api.Request) api.Response {
 	}
 	_ = s.db.Delete(fileTimestampNamespace, fileTimestampKey(req.Username, req.Path))
 	_ = s.deleteFileMetadata(req.Username, dek, req.Path)
+	s.removeUserRootIfEmpty(req.Username)
 
 	return api.Response{Success: true, Message: "Fichero borrado con exito"}
 }
@@ -636,7 +646,7 @@ func (s *server) modifyFile(req api.Request) api.Response {
 		return api.Response{Success: false, Message: err.Error()}
 	}
 
-	if perm := s.requireFilePermission(req.Username, dek, req.Path, info, 'w'); !perm.Success {
+	if perm := s.requirePathPermission(req.Username, dek, req.Path, true, 'w'); !perm.Success {
 		return perm
 	}
 
@@ -699,7 +709,7 @@ func (s *server) readFile(req api.Request) api.Response {
 	if err != nil {
 		return api.Response{Success: false, Message: "Error al leer metadatos del fichero"}
 	}
-	if perm := s.requireFilePermission(req.Username, dek, req.Path, info, 'r'); !perm.Success {
+	if perm := s.requirePathPermission(req.Username, dek, req.Path, true, 'r'); !perm.Success {
 		return perm
 	}
 
@@ -725,6 +735,9 @@ func (s *server) createDir(req api.Request) api.Response {
 	}
 	if req.Path == "" {
 		return api.Response{Success: false, Message: "Falta el path del directorio"}
+	}
+	if normalizedFilePath(req.Path) == "" {
+		return api.Response{Success: false, Message: "No se puede operar sobre la carpeta raiz del usuario"}
 	}
 	path, err := s.safePath(req.Username, req.Path)
 	if err != nil {
@@ -761,6 +774,9 @@ func (s *server) deleteDir(req api.Request) api.Response {
 	if req.Path == "" {
 		return api.Response{Success: false, Message: "Falta el path del directorio"}
 	}
+	if normalizedFilePath(req.Path) == "" {
+		return api.Response{Success: false, Message: "No se puede operar sobre la carpeta raiz del usuario"}
+	}
 	path, err := s.safePath(req.Username, req.Path)
 	if err != nil {
 		return api.Response{Success: false, Message: err.Error()}
@@ -775,7 +791,7 @@ func (s *server) deleteDir(req api.Request) api.Response {
 	if !ok {
 		return api.Response{Success: false, Message: "Sesion inconsistente: vuelve a iniciar sesion"}
 	}
-	if perm := s.requireFilePermission(req.Username, dek, req.Path, info, 'w'); !perm.Success {
+	if perm := s.requirePathPermission(req.Username, dek, req.Path, true, 'w'); !perm.Success {
 		return perm
 	}
 	_ = s.deleteFileMetadataTree(req.Username, dek, path)
@@ -784,6 +800,7 @@ func (s *server) deleteDir(req api.Request) api.Response {
 	if err := os.RemoveAll(path); err != nil {
 		return api.Response{Success: false, Message: "Error al borrar directorio"}
 	}
+	s.removeUserRootIfEmpty(req.Username)
 
 	return api.Response{Success: true, Message: "Directorio borrado con exito"}
 }
@@ -812,7 +829,7 @@ func (s *server) listFiles(req api.Request) api.Response {
 	if !dirInfo.IsDir() {
 		return api.Response{Success: false, Message: "La ruta no es un directorio"}
 	}
-	if perm := s.requireFilePermission(req.Username, dek, req.Path, dirInfo, 'r'); !perm.Success {
+	if perm := s.requirePathPermission(req.Username, dek, req.Path, true, 'r'); !perm.Success {
 		return perm
 	}
 
@@ -887,6 +904,9 @@ func (s *server) updateFileMetadata(req api.Request) api.Response {
 	}
 	if req.Path == "" {
 		return api.Response{Success: false, Message: "Falta el path del fichero o directorio"}
+	}
+	if normalizedFilePath(req.Path) == "" {
+		return api.Response{Success: false, Message: "No se puede modificar la carpeta raiz del usuario"}
 	}
 	if !validFilePermissions(req.Data) {
 		return api.Response{Success: false, Message: "Permisos invalidos: usa formato rwx------"}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -186,6 +186,10 @@ func (s *server) apiHandler(w http.ResponseWriter, r *http.Request) {
 		res = s.deleteDir(req)
 	case api.ActionListFiles:
 		res = s.listFiles(req)
+	case api.ActionGetFileMetadata:
+		res = s.getFileMetadata(req)
+	case api.ActionUpdateFileMetadata:
+		res = s.updateFileMetadata(req)
 	// TOTP
 	case api.ActionTOTPSetup:
 		res = s.tOTPSetup(req)
@@ -543,6 +547,10 @@ func (s *server) createFile(req api.Request) api.Response {
 		return api.Response{Success: false, Message: "Sesion inconsistente: vuelve a iniciar sesion"}
 	}
 
+	if parentPerm := s.requireParentDirWrite(req.Username, dek, req.Path); !parentPerm.Success {
+		return parentPerm
+	}
+
 	encrypted, err := encryptFileData(dek, req.Path, []byte(req.Data))
 	if err != nil {
 		return api.Response{Success: false, Message: "Error al cifrar el fichero"}
@@ -554,6 +562,14 @@ func (s *server) createFile(req api.Request) api.Response {
 
 	if err := s.storeFileTimestamp(req.Username, req.Path, path, dek); err != nil {
 		return api.Response{Success: false, Message: "Fichero creado, pero no se pudo guardar su timestamp"}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return api.Response{Success: false, Message: "Fichero creado, pero no se pudieron leer sus metadatos"}
+	}
+	if _, err := s.ensureFileMetadata(req.Username, dek, req.Path, info); err != nil {
+		return api.Response{Success: false, Message: "Fichero creado, pero no se pudieron guardar sus metadatos"}
 	}
 
 	return api.Response{Success: true, Message: "Fichero creado con exito"}
@@ -576,10 +592,20 @@ func (s *server) deleteFile(req api.Request) api.Response {
 		return api.Response{Success: false, Message: "El fichero no existe o es un directorio"}
 	}
 
+	dek, ok := s.getSessionKey(req.Username)
+	if !ok {
+		return api.Response{Success: false, Message: "Sesion inconsistente: vuelve a iniciar sesion"}
+	}
+
+	if perm := s.requireFilePermission(req.Username, dek, req.Path, info, 'w'); !perm.Success {
+		return perm
+	}
+
 	if err := os.Remove(path); err != nil {
 		return api.Response{Success: false, Message: "Error al borrar fichero"}
 	}
 	_ = s.db.Delete(fileTimestampNamespace, fileTimestampKey(req.Username, req.Path))
+	_ = s.deleteFileMetadata(req.Username, dek, req.Path)
 
 	return api.Response{Success: true, Message: "Fichero borrado con exito"}
 }
@@ -610,6 +636,10 @@ func (s *server) modifyFile(req api.Request) api.Response {
 		return api.Response{Success: false, Message: err.Error()}
 	}
 
+	if perm := s.requireFilePermission(req.Username, dek, req.Path, info, 'w'); !perm.Success {
+		return perm
+	}
+
 	encrypted, err := encryptFileData(dek, req.Path, []byte(req.Data))
 	if err != nil {
 		return api.Response{Success: false, Message: "Error al cifrar el fichero"}
@@ -621,6 +651,19 @@ func (s *server) modifyFile(req api.Request) api.Response {
 
 	if err := s.storeFileTimestamp(req.Username, req.Path, path, dek); err != nil {
 		return api.Response{Success: false, Message: "Fichero modificado, pero no se pudo actualizar su timestamp"}
+	}
+
+	info, err = os.Stat(path)
+	if err != nil {
+		return api.Response{Success: false, Message: "Fichero modificado, pero no se pudieron leer sus metadatos"}
+	}
+	meta, err := s.ensureFileMetadata(req.Username, dek, req.Path, info)
+	if err != nil {
+		return api.Response{Success: false, Message: "Fichero modificado, pero no se pudieron recuperar sus metadatos"}
+	}
+	meta.ModifiedAt = time.Now().UTC()
+	if err := s.saveFileMetadata(req.Username, dek, meta); err != nil {
+		return api.Response{Success: false, Message: "Fichero modificado, pero no se pudieron actualizar sus metadatos"}
 	}
 
 	return api.Response{Success: true, Message: "Fichero modificado con exito"}
@@ -652,9 +695,25 @@ func (s *server) readFile(req api.Request) api.Response {
 		return api.Response{Success: false, Message: err.Error()}
 	}
 
+	info, err := os.Stat(path)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al leer metadatos del fichero"}
+	}
+	if perm := s.requireFilePermission(req.Username, dek, req.Path, info, 'r'); !perm.Success {
+		return perm
+	}
+
 	plaintext, err := decryptFileData(dek, req.Path, data)
 	if err != nil {
 		return api.Response{Success: false, Message: "Error al descifrar el fichero"}
+	}
+
+	info, err = os.Stat(path)
+	if err == nil {
+		if meta, metaErr := s.ensureFileMetadata(req.Username, dek, req.Path, info); metaErr == nil {
+			meta.AccessedAt = time.Now().UTC()
+			_ = s.saveFileMetadata(req.Username, dek, meta)
+		}
 	}
 
 	return api.Response{Success: true, Message: "Fichero leido con exito", Data: string(plaintext)}
@@ -672,8 +731,24 @@ func (s *server) createDir(req api.Request) api.Response {
 		return api.Response{Success: false, Message: err.Error()}
 	}
 
+	dek, ok := s.getSessionKey(req.Username)
+	if !ok {
+		return api.Response{Success: false, Message: "Sesion inconsistente: vuelve a iniciar sesion"}
+	}
+	if parentPerm := s.requireParentDirWrite(req.Username, dek, req.Path); !parentPerm.Success {
+		return parentPerm
+	}
+
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return api.Response{Success: false, Message: "Error al crear el directorio"}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return api.Response{Success: false, Message: "Directorio creado, pero no se pudieron leer sus metadatos"}
+	}
+	if _, err := s.ensureFileMetadata(req.Username, dek, req.Path, info); err != nil {
+		return api.Response{Success: false, Message: "Directorio creado, pero no se pudieron guardar sus metadatos"}
 	}
 
 	return api.Response{Success: true, Message: "Directorio creado con exito"}
@@ -696,6 +771,16 @@ func (s *server) deleteDir(req api.Request) api.Response {
 		return api.Response{Success: false, Message: "El directorio no existe o no es un directorio"}
 	}
 
+	dek, ok := s.getSessionKey(req.Username)
+	if !ok {
+		return api.Response{Success: false, Message: "Sesion inconsistente: vuelve a iniciar sesion"}
+	}
+	if perm := s.requireFilePermission(req.Username, dek, req.Path, info, 'w'); !perm.Success {
+		return perm
+	}
+	_ = s.deleteFileMetadataTree(req.Username, dek, path)
+	_ = s.deleteFileTimestampsTree(req.Username, req.Path)
+
 	if err := os.RemoveAll(path); err != nil {
 		return api.Response{Success: false, Message: "Error al borrar directorio"}
 	}
@@ -713,28 +798,146 @@ func (s *server) listFiles(req api.Request) api.Response {
 		return api.Response{Success: false, Message: err.Error()}
 	}
 
+	dek, ok := s.getSessionKey(req.Username)
+	if !ok {
+		return api.Response{Success: false, Message: "Sesion inconsistente: vuelve a iniciar sesion"}
+	}
+	dirInfo, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return api.Response{Success: true, Message: "Directorio vacio", Files: []string{}, FileEntries: []api.FileEntry{}}
+		}
+		return api.Response{Success: false, Message: "Error al listar ficheros"}
+	}
+	if !dirInfo.IsDir() {
+		return api.Response{Success: false, Message: "La ruta no es un directorio"}
+	}
+	if perm := s.requireFilePermission(req.Username, dek, req.Path, dirInfo, 'r'); !perm.Success {
+		return perm
+	}
+
 	var files []string
+	var fileEntries []api.FileEntry
 	entries, err := os.ReadDir(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return api.Response{Success: true, Message: "Directorio vacio", Files: []string{}}
+			return api.Response{Success: true, Message: "Directorio vacio", Files: []string{}, FileEntries: []api.FileEntry{}}
 		}
 		return api.Response{Success: false, Message: "Error al listar ficheros"}
 	}
 
+	parentPath := normalizedFilePath(req.Path)
 	for _, entry := range entries {
 		suffix := ""
 		if entry.IsDir() {
 			suffix = "/"
 		}
 		files = append(files, entry.Name()+suffix)
+		childPath := entry.Name()
+		if parentPath != "" {
+			childPath = parentPath + "/" + entry.Name()
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return api.Response{Success: false, Message: "Error al leer metadatos del listado"}
+		}
+		meta, err := s.ensureFileMetadata(req.Username, dek, childPath, info)
+		if err != nil {
+			return api.Response{Success: false, Message: "Error al preparar metadatos del listado"}
+		}
+		fileEntries = append(fileEntries, api.FileEntry{
+			Name:     entry.Name() + suffix,
+			Path:     childPath,
+			Metadata: &meta,
+		})
 	}
 
-	return api.Response{Success: true, Message: "Listado correcto", Files: files}
+	return api.Response{Success: true, Message: "Listado correcto", Files: files, FileEntries: fileEntries}
+}
+
+func (s *server) getFileMetadata(req api.Request) api.Response {
+	if !s.isTokenValid(req.Username, req.Token) {
+		return api.Response{Success: false, Message: "Token invalido o sesion expirada", SessionExpired: true}
+	}
+	if req.Path == "" {
+		return api.Response{Success: false, Message: "Falta el path del fichero o directorio"}
+	}
+	path, err := s.safePath(req.Username, req.Path)
+	if err != nil {
+		return api.Response{Success: false, Message: err.Error()}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return api.Response{Success: false, Message: "El fichero o directorio no existe"}
+	}
+	dek, ok := s.getSessionKey(req.Username)
+	if !ok {
+		return api.Response{Success: false, Message: "Sesion inconsistente: vuelve a iniciar sesion", SessionExpired: true}
+	}
+	meta, err := s.ensureFileMetadata(req.Username, dek, req.Path, info)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al obtener metadatos"}
+	}
+	return api.Response{Success: true, Message: "Metadatos obtenidos", FileMetadata: &meta}
+}
+
+func (s *server) updateFileMetadata(req api.Request) api.Response {
+	if !s.isTokenValid(req.Username, req.Token) {
+		return api.Response{Success: false, Message: "Token invalido o sesion expirada", SessionExpired: true}
+	}
+	if req.Path == "" {
+		return api.Response{Success: false, Message: "Falta el path del fichero o directorio"}
+	}
+	if !validFilePermissions(req.Data) {
+		return api.Response{Success: false, Message: "Permisos invalidos: usa formato rwx------"}
+	}
+	path, err := s.safePath(req.Username, req.Path)
+	if err != nil {
+		return api.Response{Success: false, Message: err.Error()}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return api.Response{Success: false, Message: "El fichero o directorio no existe"}
+	}
+	dek, ok := s.getSessionKey(req.Username)
+	if !ok {
+		return api.Response{Success: false, Message: "Sesion inconsistente: vuelve a iniciar sesion", SessionExpired: true}
+	}
+	meta, err := s.ensureFileMetadata(req.Username, dek, req.Path, info)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al obtener metadatos"}
+	}
+	meta.Permissions = req.Data
+	meta.ModifiedAt = time.Now().UTC()
+	if err := s.saveFileMetadata(req.Username, dek, meta); err != nil {
+		return api.Response{Success: false, Message: "Error al actualizar metadatos"}
+	}
+	return api.Response{Success: true, Message: "Metadatos actualizados", FileMetadata: &meta}
 }
 
 func fileTimestampKey(username, reqPath string) []byte {
 	return []byte(username + "\x00" + reqPath)
+}
+
+func (s *server) deleteFileTimestampsTree(username, reqPath string) error {
+	rootKey := string(fileTimestampKey(username, reqPath))
+	keys, err := s.db.KeysByPrefix(fileTimestampNamespace, []byte(rootKey))
+	if err != nil {
+		if errors.Is(err, store.ErrNamespaceNotFound) {
+			return nil
+		}
+		return err
+	}
+	for _, key := range keys {
+		keyText := string(key)
+		if keyText != rootKey && !strings.HasPrefix(keyText, rootKey+"/") && !strings.HasPrefix(keyText, rootKey+"\\") {
+			continue
+		}
+		if err := s.db.Delete(fileTimestampNamespace, key); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *server) storeFileTimestamp(username, reqPath, absPath string, baseDEK []byte) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -908,8 +908,20 @@ func (s *server) updateFileMetadata(req api.Request) api.Response {
 	if normalizedFilePath(req.Path) == "" {
 		return api.Response{Success: false, Message: "No se puede modificar la carpeta raiz del usuario"}
 	}
-	if !validFilePermissions(req.Data) {
+	if req.Data == "" && req.Role == "" {
+		return api.Response{Success: false, Message: "No hay cambios de metadatos"}
+	}
+	if req.Data != "" && !validFilePermissions(req.Data) {
 		return api.Response{Success: false, Message: "Permisos invalidos: usa formato rwx------"}
+	}
+	if req.Role != "" {
+		exists, err := s.roles.RoleExists(req.Role)
+		if err != nil {
+			return api.Response{Success: false, Message: "Error al comprobar rol"}
+		}
+		if !exists {
+			return api.Response{Success: false, Message: "El rol indicado no existe"}
+		}
 	}
 	path, err := s.safePath(req.Username, req.Path)
 	if err != nil {
@@ -927,7 +939,12 @@ func (s *server) updateFileMetadata(req api.Request) api.Response {
 	if err != nil {
 		return api.Response{Success: false, Message: "Error al obtener metadatos"}
 	}
-	meta.Permissions = req.Data
+	if req.Data != "" {
+		meta.Permissions = req.Data
+	}
+	if req.Role != "" {
+		meta.Role = req.Role
+	}
 	meta.ModifiedAt = time.Now().UTC()
 	if err := s.saveFileMetadata(req.Username, dek, meta); err != nil {
 		return api.Response{Success: false, Message: "Error al actualizar metadatos"}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -152,6 +152,31 @@ func TestServer_FileMetadataLifecycle(t *testing.T) {
 		Username: "alice",
 		Token:    token,
 		Path:     "nota.txt",
+		Role:     roles.DefaultRole,
+	})
+	if !r.Success || r.FileMetadata == nil {
+		t.Fatalf("updateFileMetadata de rol fallo: success=%v msg=%q", r.Success, r.Message)
+	}
+	if r.FileMetadata.Role != roles.DefaultRole {
+		t.Fatalf("rol no actualizado: %+v", *r.FileMetadata)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Role:     "rol-inexistente",
+	})
+	if r.Success {
+		t.Fatal("updateFileMetadata deberia rechazar un rol inexistente")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
 		Data:     "rw-------",
 	})
 	if !r.Success {
@@ -669,6 +694,43 @@ func TestServer_FileLogicalPermissionsAncestorRestrictsDescendants(t *testing.T)
 	})
 	if r.Success {
 		t.Fatal("c1/c2/c3 no deberia permitir crear porque c1 no tiene w")
+	}
+}
+
+func TestServer_FileLogicalPermissionsSelectOwnerRoleAndOthers(t *testing.T) {
+	dir := t.TempDir()
+	db, err := store.NewStore("bbolt", filepath.Join(dir, "server.db"))
+	if err != nil {
+		t.Fatalf("no se ha podido crear la store: %v", err)
+	}
+	defer db.Close()
+
+	rs := roles.NewRoleStore(db)
+	if err := rs.CreateRole("reviewers"); err != nil {
+		t.Fatalf("CreateRole fallo: %v", err)
+	}
+	if err := rs.AssignRole("bob", "reviewers"); err != nil {
+		t.Fatalf("AssignRole fallo: %v", err)
+	}
+
+	srv := &server{roles: rs}
+	meta := api.FileMetadata{
+		Owner:       "alice",
+		Role:        "reviewers",
+		Permissions: "---r--r--",
+	}
+
+	if srv.hasLogicalPermissionForUser("alice", meta, 'r') {
+		t.Fatal("alice deberia usar la tripleta de propietario, no la de otros")
+	}
+	if !srv.hasLogicalPermissionForUser("bob", meta, 'r') {
+		t.Fatal("bob deberia recibir permiso r por su rol")
+	}
+	if !srv.hasLogicalPermissionForUser("charlie", meta, 'r') {
+		t.Fatal("charlie deberia recibir permiso r por la tripleta de otros")
+	}
+	if srv.hasLogicalPermissionForUser("bob", meta, 'w') {
+		t.Fatal("bob no deberia recibir permiso w por su rol")
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -71,6 +71,571 @@ func newTestTLSServer(t *testing.T) (*httptest.Server, string, string) {
 	return ts, dir, dbPath
 }
 
+func TestServer_FileMetadataLifecycle(t *testing.T) {
+	ts, _, dbPath := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("createFile fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionGetFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if !r.Success || r.FileMetadata == nil {
+		t.Fatalf("getFileMetadata fallo: success=%v msg=%q", r.Success, r.Message)
+	}
+	meta := r.FileMetadata
+	if meta.Owner != "alice" || meta.Permissions != "rw-------" || meta.Name != "nota.txt" || meta.IsDir {
+		t.Fatalf("metadatos iniciales inesperados: %+v", *meta)
+	}
+	if meta.CreatedAt.IsZero() || meta.ModifiedAt.IsZero() || meta.Platform == "" || meta.Size == 0 {
+		t.Fatalf("metadatos incompletos: %+v", *meta)
+	}
+	initialModifiedAt := meta.ModifiedAt
+
+	dbBytes, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("no se pudo leer server.db: %v", err)
+	}
+	if strings.Contains(string(dbBytes), "rw-------") || strings.Contains(string(dbBytes), `"permissions"`) {
+		t.Fatalf("los metadatos quedaron en claro en server.db")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "r--------",
+	})
+	if !r.Success || r.FileMetadata == nil {
+		t.Fatalf("updateFileMetadata fallo: success=%v msg=%q", r.Success, r.Message)
+	}
+	if r.FileMetadata.Permissions != "r--------" {
+		t.Fatalf("permisos no actualizados: %+v", *r.FileMetadata)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "rw-------",
+	})
+	if !r.Success {
+		t.Fatalf("updateFileMetadata para restaurar permisos fallo: %s", r.Message)
+	}
+
+	time.Sleep(2 * time.Millisecond)
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionModifyFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "contenido modificado",
+	})
+	if !r.Success {
+		t.Fatalf("modifyFile fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionGetFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if !r.Success || r.FileMetadata == nil {
+		t.Fatalf("getFileMetadata tras modificar fallo: success=%v msg=%q", r.Success, r.Message)
+	}
+	if !r.FileMetadata.ModifiedAt.After(initialModifiedAt) {
+		t.Fatalf("ModifiedAt no se actualizo: antes=%s despues=%s", initialModifiedAt, r.FileMetadata.ModifiedAt)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionReadFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if !r.Success {
+		t.Fatalf("readFile fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionGetFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if !r.Success || r.FileMetadata == nil || r.FileMetadata.AccessedAt.IsZero() {
+		t.Fatalf("AccessedAt no se actualizo: success=%v msg=%q meta=%+v", r.Success, r.Message, r.FileMetadata)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionListFiles,
+		Username: "alice",
+		Token:    token,
+	})
+	if !r.Success || len(r.FileEntries) != 1 || r.FileEntries[0].Metadata == nil {
+		t.Fatalf("listFiles no devolvio FileEntries con metadatos: success=%v msg=%q entries=%+v", r.Success, r.Message, r.FileEntries)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionDeleteFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if !r.Success {
+		t.Fatalf("deleteFile fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionGetFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if r.Success {
+		t.Fatal("getFileMetadata deberia fallar tras borrar el fichero")
+	}
+}
+
+func TestServer_FileMetadataRejectsInvalidTokenAndTraversal(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("createFile fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionGetFileMetadata,
+		Username: "alice",
+		Token:    "token-invalido",
+		Path:     "nota.txt",
+	})
+	if r.Success {
+		t.Fatal("getFileMetadata deberia fallar con token invalido")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    "token-invalido",
+		Path:     "nota.txt",
+		Data:     "rw-------",
+	})
+	if r.Success {
+		t.Fatal("updateFileMetadata deberia fallar con token invalido")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionGetFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "../nota.txt",
+	})
+	if r.Success {
+		t.Fatal("getFileMetadata deberia rechazar path traversal")
+	}
+}
+
+func TestServer_FileLogicalPermissionsControlFileOperations(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("createFile fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "r--------",
+	})
+	if !r.Success {
+		t.Fatalf("updateFileMetadata fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionReadFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if !r.Success || r.Data != "contenido" {
+		t.Fatalf("readFile deberia permitir r--------: success=%v msg=%q data=%q", r.Success, r.Message, r.Data)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionModifyFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "nuevo",
+	})
+	if r.Success {
+		t.Fatal("modifyFile deberia fallar sin permiso w")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionDeleteFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if r.Success {
+		t.Fatal("deleteFile deberia fallar sin permiso w")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "-w-------",
+	})
+	if !r.Success {
+		t.Fatalf("updateFileMetadata para recuperar w fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionReadFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if r.Success {
+		t.Fatal("readFile deberia fallar sin permiso r")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionModifyFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "nuevo",
+	})
+	if !r.Success {
+		t.Fatalf("modifyFile deberia permitir -w-------: %s", r.Message)
+	}
+}
+
+func TestServer_FileLogicalPermissionsControlDirectoryOperations(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateDir,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs",
+	})
+	if !r.Success {
+		t.Fatalf("createDir fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs",
+		Data:     "r-x------",
+	})
+	if !r.Success {
+		t.Fatalf("updateFileMetadata fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs/nota.txt",
+		Data:     "contenido",
+	})
+	if r.Success {
+		t.Fatal("createFile deberia fallar sin permiso w en directorio padre")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionListFiles,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs",
+	})
+	if !r.Success {
+		t.Fatalf("listFiles deberia permitir r-x------: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs",
+		Data:     "-wx------",
+	})
+	if !r.Success {
+		t.Fatalf("updateFileMetadata para recuperar w fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionListFiles,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs",
+	})
+	if r.Success {
+		t.Fatal("listFiles deberia fallar sin permiso r en directorio")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs/nota.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("createFile deberia permitir -wx------: %s", r.Message)
+	}
+}
+
+func TestServer_FileMetadataDirectoryLifecycle(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateDir,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs",
+	})
+	if !r.Success {
+		t.Fatalf("createDir fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs/nota.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("createFile fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionGetFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs",
+	})
+	if !r.Success || r.FileMetadata == nil || !r.FileMetadata.IsDir || r.FileMetadata.Permissions != "rwx------" {
+		t.Fatalf("metadatos de directorio inesperados: success=%v msg=%q meta=%+v", r.Success, r.Message, r.FileMetadata)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionDeleteDir,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs",
+	})
+	if !r.Success {
+		t.Fatalf("deleteDir fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionGetFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "docs/nota.txt",
+	})
+	if r.Success {
+		t.Fatal("getFileMetadata del hijo deberia fallar tras borrar el directorio")
+	}
+}
+
+func TestServer_FileTimestampStillDetectsExternalModification(t *testing.T) {
+	ts, dir, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("createFile fallo: %s", r.Message)
+	}
+
+	path := filepath.Join(dir, "data", "files", "alice", "nota.txt")
+	time.Sleep(2 * time.Millisecond)
+	if err := os.WriteFile(path, []byte("modificado fuera"), 0644); err != nil {
+		t.Fatalf("no se pudo modificar fichero fuera de Sprout: %v", err)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionReadFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if r.Success || !strings.Contains(strings.ToLower(r.Message), "modificado fuera") {
+		t.Fatalf("readFile deberia detectar modificacion externa: success=%v msg=%q", r.Success, r.Message)
+	}
+}
+
 func postJSON(t *testing.T, client *http.Client, url string, v any) (*http.Response, api.Response) {
 	t.Helper()
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -509,6 +509,231 @@ func TestServer_FileLogicalPermissionsControlDirectoryOperations(t *testing.T) {
 	}
 }
 
+func TestServer_FileLogicalPermissionsUseAncestorTree(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	for _, dir := range []string{"c1", "c1/c2", "c1/c2/c3"} {
+		_, r = postJSON(t, httpClient, apiURL, api.Request{
+			Action:   api.ActionCreateDir,
+			Username: "alice",
+			Token:    token,
+			Path:     dir,
+		})
+		if !r.Success {
+			t.Fatalf("createDir(%s) fallo: %s", dir, r.Message)
+		}
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "c1/c2",
+		Data:     "r--------",
+	})
+	if !r.Success {
+		t.Fatalf("update c2 fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "c1/c2/c3",
+		Data:     "---------",
+	})
+	if !r.Success {
+		t.Fatalf("update c3 fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionListFiles,
+		Username: "alice",
+		Token:    token,
+		Path:     "c1/c2",
+	})
+	if !r.Success {
+		t.Fatalf("c1/c2 deberia permitir leer por permisos efectivos: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "c1/c2/nota.txt",
+		Data:     "contenido",
+	})
+	if r.Success {
+		t.Fatal("c1/c2 no deberia permitir crear sin permiso w efectivo")
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionListFiles,
+		Username: "alice",
+		Token:    token,
+		Path:     "c1/c2/c3",
+	})
+	if r.Success {
+		t.Fatal("c1/c2/c3 no deberia permitir leer por c3 sin permisos")
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "c1/nota.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("c1 deberia seguir permitiendo crear fuera de c2: %s", r.Message)
+	}
+}
+
+func TestServer_FileLogicalPermissionsAncestorRestrictsDescendants(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	for _, dir := range []string{"c1", "c1/c2", "c1/c2/c3"} {
+		_, r = postJSON(t, httpClient, apiURL, api.Request{
+			Action:   api.ActionCreateDir,
+			Username: "alice",
+			Token:    token,
+			Path:     dir,
+		})
+		if !r.Success {
+			t.Fatalf("createDir(%s) fallo: %s", dir, r.Message)
+		}
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "c1",
+		Data:     "r--------",
+	})
+	if !r.Success {
+		t.Fatalf("update c1 fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionListFiles,
+		Username: "alice",
+		Token:    token,
+		Path:     "c1/c2/c3",
+	})
+	if !r.Success {
+		t.Fatalf("c1/c2/c3 deberia permitir leer porque todos tienen r efectivo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "c1/c2/c3/nota.txt",
+		Data:     "contenido",
+	})
+	if r.Success {
+		t.Fatal("c1/c2/c3 no deberia permitir crear porque c1 no tiene w")
+	}
+}
+
+func TestServer_RootDirectoryRestrictionsAndEmptyCleanup(t *testing.T) {
+	ts, dir, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionRegister,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	for _, req := range []api.Request{
+		{Action: api.ActionCreateDir, Path: "."},
+		{Action: api.ActionDeleteDir, Path: "."},
+		{Action: api.ActionUpdateFileMetadata, Path: ".", Data: "rwx------"},
+	} {
+		req.Username = "alice"
+		req.Token = token
+		_, r = postJSON(t, httpClient, apiURL, req)
+		if r.Success {
+			t.Fatalf("%s sobre raiz deberia fallar", req.Action)
+		}
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("createFile fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionDeleteFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if !r.Success {
+		t.Fatalf("deleteFile fallo: %s", r.Message)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "data", "files", "alice")); !os.IsNotExist(err) {
+		t.Fatalf("la raiz vacia del usuario deberia borrarse, stat err=%v", err)
+	}
+}
+
 func TestServer_FileMetadataDirectoryLifecycle(t *testing.T) {
 	ts, _, _ := newTestTLSServer(t)
 	apiURL := ts.URL + "/api"


### PR DESCRIPTION
## Referencias

<!-- Añade las referencias de esta PR -->
<!-- Closes #issue -->
Closes #49

## Descripción

Añade gestión de metadatos lógicos para ficheros y carpetas.
La PR incorpora nuevos endpoints para consultar y modificar metadatos, almacenamiento cifrado de metadatos en bbolt, claves opacas con HMAC para no exponer rutas, comprobación de permisos lógicos en operaciones de ficheros/carpetas y soporte en el cliente CLI para ver permisos efectivos en forma de árbol antes de operar.

## Tipo de cambio

- [x] Nueva funcionalidad
- [ ] Corrección de bug
- [x] Seguridad
- [ ] Refactor

## Checklist

- [x] El servidor arranca sin errores (`go run main.go`)
- [x] He probado el flujo completo (registro → login → operación → logout)
- [x] No hay contraseñas ni secretos hardcodeados

## Revisión

### Revisores

<!-- Añade los revisores que deben aprobar este PR -->
<!--   - @usuario1 -->

## Checklist de revisión

- [ ] El código compila sin errores (`go build ./...`)
- [ ] Los tests pasan (`go test ./...`)
- [ ] No hay contraseñas ni secretos hardcodeados
- [ ] Los errores se manejan correctamente (no hay `_` ignorando errores importantes)
- [ ] Las funciones nuevas son coherentes con el estilo del resto del proyecto
- [ ] No se exponen endpoints innecesarios
- [ ] He probado el flujo manualmente