### PR TITLE
50 sistema de notas o comentarios en los ficheros tanto del propio usuario como de otros

### DIFF
--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -305,6 +305,21 @@ Los tags se han implementado como un atributo dentro de la estructura `FileMetad
 - **Integridad de búsqueda en Carpetas Compartidas:** Tal como ocurre con la lectura de ficheros, la búsqueda de tags en una carpeta compartida (`compartida_<owner>`) resuelve primero el contexto (`resolveFileAccessContext`). Esto significa que si un miembro de la carpeta realiza el filtro por tag, usará implícitamente la clave compartida sin exponerla, y obtendrá todos los ficheros de la carpeta compartida que posean ese tag. Así, los metadatos actúan de manera colaborativa pero estrictamente acotada a quienes tienen acceso.
 - **Sanitización Robusta:** Los inputs provenientes del cliente referidos a los tags se iteran para aplicar `strings.TrimSpace`, ignorar cadenas vacías, de-duplicar resultados usando un mapa interno lógico y, finalmente, ordenarlos alfabéticamente antes de enviarse o persistirse, minimizando inyección de bytes basura o redundancia ineficiente.
 
+### Comentarios en ficheros y carpetas
+Los comentarios se modelan como una lista dentro de `FileMetadata`. Cada comentario guarda un
+identificador, autor, texto y fecha de creación. Al vivir dentro de los metadatos, quedan cifrados
+con la misma clave que el resto de atributos del fichero o carpeta: la DEK personal en rutas propias
+o la clave compartida en rutas `compartida_<owner>`.
+
+La lectura y creación de comentarios exige permiso lógico de lectura (`r`) sobre todo el árbol de la
+ruta y sobre el elemento comentado. Esto permite comentar ficheros propios y también ficheros de
+carpetas compartidas cuando el usuario pertenece al grupo y los permisos efectivos lo permiten.
+
+Los comentarios son colaborativos, no privados por usuario: cualquier usuario que pueda listar los
+comentarios de una ruta ve la misma lista. El borrado queda limitado al autor del comentario o al
+propietario del fichero/carpeta. No se implementa edición de comentarios; si un comentario contiene
+un error, se borra y se crea uno nuevo.
+
 ### Seguridad de carpetas compartidas
 Cada carpeta compartida tiene su propia clave de cifrado, guardada en la DB bajo el namespace
 `shared_folder_keys` y asociada al dueño. Así se evita reutilizar la DEK personal del usuario para

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -44,6 +44,8 @@ const (
 	ActionUpdateFileMetadata = "updateFileMetadata"
 	ActionFilterFilesByTag   = "filterFilesByTag"
 	ActionAddFileComment     = "addFileComment"
+	ActionDeleteFileComment  = "deleteFileComment"
+	ActionListFileComments   = "listFileComments"
 
 	// Role management
 	ActionAssignRole   = "assignRole"
@@ -70,6 +72,7 @@ type Request struct {
 	Tag              string   `json:"tag,omitempty"`
 	Tags             []string `json:"tags,omitempty"`
 	ClearTags        bool     `json:"clear_tags,omitempty"`
+	CommentID        string   `json:"comment_id,omitempty"`
 	CommentText      string   `json:"comment_text,omitempty"`
 	Recipient        string   `json:"recipient,omitempty"`
 	MessageID        string   `json:"message_id,omitempty"`

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -43,6 +43,7 @@ const (
 	ActionGetFileMetadata    = "getFileMetadata"
 	ActionUpdateFileMetadata = "updateFileMetadata"
 	ActionFilterFilesByTag   = "filterFilesByTag"
+	ActionAddFileComment     = "addFileComment"
 
 	// Role management
 	ActionAssignRole   = "assignRole"
@@ -69,6 +70,7 @@ type Request struct {
 	Tag              string   `json:"tag,omitempty"`
 	Tags             []string `json:"tags,omitempty"`
 	ClearTags        bool     `json:"clear_tags,omitempty"`
+	CommentText      string   `json:"comment_text,omitempty"`
 	Recipient        string   `json:"recipient,omitempty"`
 	MessageID        string   `json:"message_id,omitempty"`
 	Ciphertext       string   `json:"ciphertext,omitempty"`
@@ -90,18 +92,26 @@ type MessageSummary struct {
 }
 
 type FileMetadata struct {
-	Path        string    `json:"path"`
-	Name        string    `json:"name"`
-	IsDir       bool      `json:"is_dir"`
-	Size        int64     `json:"size"`
-	Owner       string    `json:"owner"`
-	Role        string    `json:"role,omitempty"`
-	Tags        []string  `json:"tags,omitempty"`
-	Permissions string    `json:"permissions"`
-	CreatedAt   time.Time `json:"created_at"`
-	ModifiedAt  time.Time `json:"modified_at"`
-	AccessedAt  time.Time `json:"accessed_at,omitempty"`
-	Platform    string    `json:"platform"`
+	Path        string        `json:"path"`
+	Name        string        `json:"name"`
+	IsDir       bool          `json:"is_dir"`
+	Size        int64         `json:"size"`
+	Owner       string        `json:"owner"`
+	Role        string        `json:"role,omitempty"`
+	Tags        []string      `json:"tags,omitempty"`
+	Comments    []FileComment `json:"comments,omitempty"`
+	Permissions string        `json:"permissions"`
+	CreatedAt   time.Time     `json:"created_at"`
+	ModifiedAt  time.Time     `json:"modified_at"`
+	AccessedAt  time.Time     `json:"accessed_at,omitempty"`
+	Platform    string        `json:"platform"`
+}
+
+type FileComment struct {
+	ID        string    `json:"id"`
+	Author    string    `json:"author"`
+	Text      string    `json:"text"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 type FileEntry struct {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -585,6 +585,7 @@ func (c *client) fileManagerMenu() {
 			"Crear carpeta",
 			"Borrar carpeta",
 			"Ver metadatos",
+			"Añadir comentario",
 			"Modificar permisos lógicos",
 			"Modificar rol/grupo",
 			"Modificar tags",
@@ -730,7 +731,27 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 9: // Modificar permisos lógicos
+		case 9: // Añadir comentario
+			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
+			if !c.ensureLogicalPermission(path, true, 'r', "comentar el fichero o carpeta") {
+				break
+			}
+			comment := ui.ReadMultiline("Introduce el comentario")
+			res := c.sendRequest(api.Request{
+				Action:      api.ActionAddFileComment,
+				Username:    c.currentUser,
+				Token:       c.authToken,
+				Path:        path,
+				CommentText: comment,
+			})
+			fmt.Println("Éxito:", res.Success)
+			fmt.Println("Mensaje:", res.Message)
+			if res.Success && res.FileMetadata != nil {
+				printFileMetadata(*res.FileMetadata)
+			} else {
+				c.maybeOfferDeleteOutOfSyncFile(path, res)
+			}
+		case 10: // Modificar permisos lógicos
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
 			if isClientRootPath(path) {
 				fmt.Println("Éxito: false")
@@ -752,7 +773,7 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 10: // Modificar rol/grupo
+		case 11: // Modificar rol/grupo
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
 			if isClientRootPath(path) {
 				fmt.Println("Éxito: false")
@@ -774,7 +795,7 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 11: // Modificar tags
+		case 12: // Modificar tags
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
 			if isClientRootPath(path) {
 				fmt.Println("Éxito: false")
@@ -801,7 +822,7 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 12: // Filtrar por tag
+		case 13: // Filtrar por tag
 			path := ui.ReadInput("Introduce la carpeta raíz a filtrar (deja vacío para la raíz)")
 			tag := ui.ReadInput("Introduce el tag a buscar")
 			res := c.sendRequest(api.Request{
@@ -816,7 +837,7 @@ func (c *client) fileManagerMenu() {
 			if res.Success && len(res.FileEntries) > 0 {
 				printTaggedEntriesTree(path, res.FileEntries)
 			}
-		case 13: // Ver mis carpetas compartidas
+		case 14: // Ver mis carpetas compartidas
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionListSharedFolders,
 				Username: c.currentUser,
@@ -827,9 +848,9 @@ func (c *client) fileManagerMenu() {
 			if res.Success {
 				fmt.Println("Carpetas compartidas:", res.SharedFolders)
 			}
-		case 14: // Gestionar carpeta compartida
+		case 15: // Gestionar carpeta compartida
 			c.sharedFolderMenu("compartida_" + c.currentUser)
-		case 15: // Volver al menú principal
+		case 16: // Volver al menú principal
 			return
 		}
 		ui.Pause("Pulsa [Enter] para continuar...")
@@ -1074,6 +1095,15 @@ func printFileMetadata(meta api.FileMetadata) {
 		fmt.Println("Tags:", strings.Join(meta.Tags, ", "))
 	} else {
 		fmt.Println("Tags: ninguno")
+	}
+	if len(meta.Comments) > 0 {
+		fmt.Println("Comentarios:")
+		for _, comment := range meta.Comments {
+			fmt.Printf("- %s | %s | %s\n", comment.ID, comment.Author, comment.CreatedAt.Format(time.RFC3339))
+			fmt.Println("  " + strings.ReplaceAll(comment.Text, "\n", "\n  "))
+		}
+	} else {
+		fmt.Println("Comentarios: ninguno")
 	}
 	fmt.Println("Permisos:", meta.Permissions)
 	fmt.Println("Creado:", meta.CreatedAt.Format(time.RFC3339))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -788,8 +788,14 @@ func (c *client) fileManagerMenu() {
 				c.maybeOfferDeleteOutOfSyncFile(path, listRes)
 				break
 			}
-			if !printOwnFileComments(*listRes.FileMetadata, c.currentUser) {
-				break
+			if c.currentUser == listRes.FileMetadata.Owner {
+				if !printFileComments(*listRes.FileMetadata) {
+					break
+				}
+			} else {
+				if !printOwnFileComments(*listRes.FileMetadata, c.currentUser) {
+					break
+				}
 			}
 			commentID := ui.ReadInput("Introduce el ID del comentario")
 			res := c.sendRequest(api.Request{
@@ -1170,19 +1176,20 @@ func printFileMetadata(meta api.FileMetadata) {
 	fmt.Println("-----------------")
 }
 
-func printFileComments(meta api.FileMetadata) {
+func printFileComments(meta api.FileMetadata) bool {
 	fmt.Println("--- Comentarios ---")
 	fmt.Println("Ruta:", meta.Path)
 	if len(meta.Comments) == 0 {
 		fmt.Println("Sin comentarios")
 		fmt.Println("-------------------")
-		return
+		return false
 	}
 	for _, comment := range meta.Comments {
 		fmt.Printf("- %s | %s | %s\n", comment.ID, comment.Author, comment.CreatedAt.Format(time.RFC3339))
 		fmt.Println("  " + strings.ReplaceAll(comment.Text, "\n", "\n  "))
 	}
 	fmt.Println("-------------------")
+	return true
 }
 
 func printOwnFileComments(meta api.FileMetadata, username string) bool {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -585,7 +585,9 @@ func (c *client) fileManagerMenu() {
 			"Crear carpeta",
 			"Borrar carpeta",
 			"Ver metadatos",
+			"Ver comentarios",
 			"Añadir comentario",
+			"Borrar comentario",
 			"Modificar permisos lógicos",
 			"Modificar rol/grupo",
 			"Modificar tags",
@@ -731,7 +733,25 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 9: // Añadir comentario
+		case 9: // Ver comentarios
+			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
+			if !c.ensureLogicalPermission(path, true, 'r', "ver comentarios") {
+				break
+			}
+			res := c.sendRequest(api.Request{
+				Action:   api.ActionListFileComments,
+				Username: c.currentUser,
+				Token:    c.authToken,
+				Path:     path,
+			})
+			fmt.Println("Éxito:", res.Success)
+			fmt.Println("Mensaje:", res.Message)
+			if res.Success && res.FileMetadata != nil {
+				printFileComments(*res.FileMetadata)
+			} else {
+				c.maybeOfferDeleteOutOfSyncFile(path, res)
+			}
+		case 10: // Añadir comentario
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
 			if !c.ensureLogicalPermission(path, true, 'r', "comentar el fichero o carpeta") {
 				break
@@ -751,7 +771,42 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 10: // Modificar permisos lógicos
+		case 11: // Borrar comentario
+			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
+			if !c.ensureLogicalPermission(path, true, 'r', "borrar comentario") {
+				break
+			}
+			listRes := c.sendRequest(api.Request{
+				Action:   api.ActionListFileComments,
+				Username: c.currentUser,
+				Token:    c.authToken,
+				Path:     path,
+			})
+			fmt.Println("Éxito:", listRes.Success)
+			fmt.Println("Mensaje:", listRes.Message)
+			if !listRes.Success || listRes.FileMetadata == nil {
+				c.maybeOfferDeleteOutOfSyncFile(path, listRes)
+				break
+			}
+			if !printOwnFileComments(*listRes.FileMetadata, c.currentUser) {
+				break
+			}
+			commentID := ui.ReadInput("Introduce el ID del comentario")
+			res := c.sendRequest(api.Request{
+				Action:    api.ActionDeleteFileComment,
+				Username:  c.currentUser,
+				Token:     c.authToken,
+				Path:      path,
+				CommentID: commentID,
+			})
+			fmt.Println("Éxito:", res.Success)
+			fmt.Println("Mensaje:", res.Message)
+			if res.Success && res.FileMetadata != nil {
+				printFileComments(*res.FileMetadata)
+			} else {
+				c.maybeOfferDeleteOutOfSyncFile(path, res)
+			}
+		case 12: // Modificar permisos lógicos
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
 			if isClientRootPath(path) {
 				fmt.Println("Éxito: false")
@@ -773,7 +828,7 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 11: // Modificar rol/grupo
+		case 13: // Modificar rol/grupo
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
 			if isClientRootPath(path) {
 				fmt.Println("Éxito: false")
@@ -795,7 +850,7 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 12: // Modificar tags
+		case 14: // Modificar tags
 			path := ui.ReadInput("Introduce la ruta/nombre del fichero o carpeta")
 			if isClientRootPath(path) {
 				fmt.Println("Éxito: false")
@@ -822,7 +877,7 @@ func (c *client) fileManagerMenu() {
 			} else {
 				c.maybeOfferDeleteOutOfSyncFile(path, res)
 			}
-		case 13: // Filtrar por tag
+		case 15: // Filtrar por tag
 			path := ui.ReadInput("Introduce la carpeta raíz a filtrar (deja vacío para la raíz)")
 			tag := ui.ReadInput("Introduce el tag a buscar")
 			res := c.sendRequest(api.Request{
@@ -837,7 +892,7 @@ func (c *client) fileManagerMenu() {
 			if res.Success && len(res.FileEntries) > 0 {
 				printTaggedEntriesTree(path, res.FileEntries)
 			}
-		case 14: // Ver mis carpetas compartidas
+		case 16: // Ver mis carpetas compartidas
 			res := c.sendRequest(api.Request{
 				Action:   api.ActionListSharedFolders,
 				Username: c.currentUser,
@@ -848,9 +903,9 @@ func (c *client) fileManagerMenu() {
 			if res.Success {
 				fmt.Println("Carpetas compartidas:", res.SharedFolders)
 			}
-		case 15: // Gestionar carpeta compartida
+		case 17: // Gestionar carpeta compartida
 			c.sharedFolderMenu("compartida_" + c.currentUser)
-		case 16: // Volver al menú principal
+		case 18: // Volver al menú principal
 			return
 		}
 		ui.Pause("Pulsa [Enter] para continuar...")
@@ -1099,8 +1154,8 @@ func printFileMetadata(meta api.FileMetadata) {
 	if len(meta.Comments) > 0 {
 		fmt.Println("Comentarios:")
 		for _, comment := range meta.Comments {
-			fmt.Printf("- %s | %s | %s\n", comment.ID, comment.Author, comment.CreatedAt.Format(time.RFC3339))
-			fmt.Println("  " + strings.ReplaceAll(comment.Text, "\n", "\n  "))
+			text := strings.ReplaceAll(comment.Text, "\n", " ")
+			fmt.Printf("- %s | %s | %s\n", text, comment.Author, comment.CreatedAt.Format(time.RFC3339))
 		}
 	} else {
 		fmt.Println("Comentarios: ninguno")
@@ -1113,6 +1168,40 @@ func printFileMetadata(meta api.FileMetadata) {
 	}
 	fmt.Println("Plataforma:", meta.Platform)
 	fmt.Println("-----------------")
+}
+
+func printFileComments(meta api.FileMetadata) {
+	fmt.Println("--- Comentarios ---")
+	fmt.Println("Ruta:", meta.Path)
+	if len(meta.Comments) == 0 {
+		fmt.Println("Sin comentarios")
+		fmt.Println("-------------------")
+		return
+	}
+	for _, comment := range meta.Comments {
+		fmt.Printf("- %s | %s | %s\n", comment.ID, comment.Author, comment.CreatedAt.Format(time.RFC3339))
+		fmt.Println("  " + strings.ReplaceAll(comment.Text, "\n", "\n  "))
+	}
+	fmt.Println("-------------------")
+}
+
+func printOwnFileComments(meta api.FileMetadata, username string) bool {
+	fmt.Println("--- Tus comentarios ---")
+	fmt.Println("Ruta:", meta.Path)
+	found := false
+	for _, comment := range meta.Comments {
+		if comment.Author != username {
+			continue
+		}
+		found = true
+		fmt.Printf("- %s | %s | %s\n", comment.ID, comment.Author, comment.CreatedAt.Format(time.RFC3339))
+		fmt.Println("  " + strings.ReplaceAll(comment.Text, "\n", "\n  "))
+	}
+	if !found {
+		fmt.Println("No tienes comentarios en esta ruta")
+	}
+	fmt.Println("-----------------------")
+	return found
 }
 
 func parseTagList(input string) []string {

--- a/pkg/server/file_comments.go
+++ b/pkg/server/file_comments.go
@@ -9,33 +9,57 @@ import (
 	"sprout/pkg/utils"
 )
 
-func (s *server) addFileComment(req api.Request) api.Response {
+func (s *server) loadCommentableFileMetadata(req api.Request) (api.FileMetadata, fileAccessContext, errorResponse) {
 	if !s.isTokenValid(req.Username, req.Token) {
-		return api.Response{Success: false, Message: "Token invalido o sesion expirada", SessionExpired: true}
+		return api.FileMetadata{}, fileAccessContext{}, errorResponse{api.Response{Success: false, Message: "Token invalido o sesion expirada", SessionExpired: true}}
 	}
 	if req.Path == "" {
-		return api.Response{Success: false, Message: "Falta el path del fichero o directorio"}
+		return api.FileMetadata{}, fileAccessContext{}, errorResponse{api.Response{Success: false, Message: "Falta el path del fichero o directorio"}}
 	}
+
+	ctx, err := s.resolveFileAccessContext(req.Username, req.Path)
+	if err != nil {
+		return api.FileMetadata{}, fileAccessContext{}, errorResponse{api.Response{Success: false, Message: err.Error()}}
+	}
+	info, err := os.Stat(ctx.absPath)
+	if err != nil {
+		return api.FileMetadata{}, fileAccessContext{}, errorResponse{api.Response{Success: false, Message: "El fichero o directorio no existe"}}
+	}
+	if perm := s.requirePathPermission(req.Username, ctx.baseDEK, req.Path, true, 'r'); !perm.Success {
+		return api.FileMetadata{}, fileAccessContext{}, errorResponse{perm}
+	}
+	meta, err := s.ensureFileMetadata(ctx.storageUser, ctx.baseDEK, req.Path, info)
+	if err != nil {
+		return api.FileMetadata{}, fileAccessContext{}, errorResponse{api.Response{Success: false, Message: "Error al obtener metadatos"}}
+	}
+	return meta, ctx, errorResponse{}
+}
+
+type errorResponse struct {
+	response api.Response
+}
+
+func (e errorResponse) failed() bool {
+	return e.response.Message != "" || e.response.SessionExpired
+}
+
+func (s *server) listFileComments(req api.Request) api.Response {
+	meta, _, errRes := s.loadCommentableFileMetadata(req)
+	if errRes.failed() {
+		return errRes.response
+	}
+	return api.Response{Success: true, Message: "Comentarios obtenidos", FileMetadata: &meta}
+}
+
+func (s *server) addFileComment(req api.Request) api.Response {
 	text := strings.TrimSpace(req.CommentText)
 	if text == "" {
 		return api.Response{Success: false, Message: "El comentario no puede estar vacio"}
 	}
 
-	ctx, err := s.resolveFileAccessContext(req.Username, req.Path)
-	if err != nil {
-		return api.Response{Success: false, Message: err.Error()}
-	}
-	info, err := os.Stat(ctx.absPath)
-	if err != nil {
-		return api.Response{Success: false, Message: "El fichero o directorio no existe"}
-	}
-	if perm := s.requirePathPermission(req.Username, ctx.baseDEK, req.Path, true, 'r'); !perm.Success {
-		return perm
-	}
-
-	meta, err := s.ensureFileMetadata(ctx.storageUser, ctx.baseDEK, req.Path, info)
-	if err != nil {
-		return api.Response{Success: false, Message: "Error al obtener metadatos"}
+	meta, ctx, errRes := s.loadCommentableFileMetadata(req)
+	if errRes.failed() {
+		return errRes.response
 	}
 	id, err := utils.NewRandomToken(12)
 	if err != nil {
@@ -52,4 +76,38 @@ func (s *server) addFileComment(req api.Request) api.Response {
 		return api.Response{Success: false, Message: "Error al guardar comentario"}
 	}
 	return api.Response{Success: true, Message: "Comentario añadido", FileMetadata: &meta}
+}
+
+func (s *server) deleteFileComment(req api.Request) api.Response {
+	commentID := strings.TrimSpace(req.CommentID)
+	if commentID == "" {
+		return api.Response{Success: false, Message: "Falta el identificador del comentario"}
+	}
+
+	meta, ctx, errRes := s.loadCommentableFileMetadata(req)
+	if errRes.failed() {
+		return errRes.response
+	}
+
+	found := -1
+	for i, comment := range meta.Comments {
+		if comment.ID == commentID {
+			found = i
+			break
+		}
+	}
+	if found == -1 {
+		return api.Response{Success: false, Message: "Comentario no encontrado"}
+	}
+	comment := meta.Comments[found]
+	if req.Username != comment.Author && req.Username != meta.Owner {
+		return api.Response{Success: false, Message: "No autorizado"}
+	}
+
+	meta.Comments = append(meta.Comments[:found], meta.Comments[found+1:]...)
+	meta.ModifiedAt = time.Now().UTC()
+	if err := s.saveFileMetadata(ctx.storageUser, ctx.baseDEK, meta); err != nil {
+		return api.Response{Success: false, Message: "Error al borrar comentario"}
+	}
+	return api.Response{Success: true, Message: "Comentario borrado", FileMetadata: &meta}
 }

--- a/pkg/server/file_comments.go
+++ b/pkg/server/file_comments.go
@@ -9,6 +9,11 @@ import (
 	"sprout/pkg/utils"
 )
 
+const (
+	maxFileCommentBytes    = 4096
+	maxFileCommentsPerFile = 100
+)
+
 func (s *server) loadCommentableFileMetadata(req api.Request) (api.FileMetadata, fileAccessContext, errorResponse) {
 	if !s.isTokenValid(req.Username, req.Token) {
 		return api.FileMetadata{}, fileAccessContext{}, errorResponse{api.Response{Success: false, Message: "Token invalido o sesion expirada", SessionExpired: true}}
@@ -25,7 +30,7 @@ func (s *server) loadCommentableFileMetadata(req api.Request) (api.FileMetadata,
 	if err != nil {
 		return api.FileMetadata{}, fileAccessContext{}, errorResponse{api.Response{Success: false, Message: "El fichero o directorio no existe"}}
 	}
-	if perm := s.requirePathPermission(req.Username, ctx.baseDEK, req.Path, true, 'r'); !perm.Success {
+	if perm := s.requirePathPermissionForContext(req.Username, ctx, req.Path, true, 'r', info); !perm.Success {
 		return api.FileMetadata{}, fileAccessContext{}, errorResponse{perm}
 	}
 	meta, err := s.ensureFileMetadata(ctx.storageUser, ctx.baseDEK, req.Path, info)
@@ -56,10 +61,16 @@ func (s *server) addFileComment(req api.Request) api.Response {
 	if text == "" {
 		return api.Response{Success: false, Message: "El comentario no puede estar vacio"}
 	}
+	if len([]byte(text)) > maxFileCommentBytes {
+		return api.Response{Success: false, Message: "El comentario supera el tamano maximo permitido"}
+	}
 
 	meta, ctx, errRes := s.loadCommentableFileMetadata(req)
 	if errRes.failed() {
 		return errRes.response
+	}
+	if len(meta.Comments) >= maxFileCommentsPerFile {
+		return api.Response{Success: false, Message: "Se ha alcanzado el numero maximo de comentarios para esta ruta"}
 	}
 	id, err := utils.NewRandomToken(12)
 	if err != nil {

--- a/pkg/server/file_comments.go
+++ b/pkg/server/file_comments.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"sprout/pkg/api"
+	"sprout/pkg/utils"
+)
+
+func (s *server) addFileComment(req api.Request) api.Response {
+	if !s.isTokenValid(req.Username, req.Token) {
+		return api.Response{Success: false, Message: "Token invalido o sesion expirada", SessionExpired: true}
+	}
+	if req.Path == "" {
+		return api.Response{Success: false, Message: "Falta el path del fichero o directorio"}
+	}
+	text := strings.TrimSpace(req.CommentText)
+	if text == "" {
+		return api.Response{Success: false, Message: "El comentario no puede estar vacio"}
+	}
+
+	ctx, err := s.resolveFileAccessContext(req.Username, req.Path)
+	if err != nil {
+		return api.Response{Success: false, Message: err.Error()}
+	}
+	info, err := os.Stat(ctx.absPath)
+	if err != nil {
+		return api.Response{Success: false, Message: "El fichero o directorio no existe"}
+	}
+	if perm := s.requirePathPermission(req.Username, ctx.baseDEK, req.Path, true, 'r'); !perm.Success {
+		return perm
+	}
+
+	meta, err := s.ensureFileMetadata(ctx.storageUser, ctx.baseDEK, req.Path, info)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al obtener metadatos"}
+	}
+	id, err := utils.NewRandomToken(12)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al generar identificador del comentario"}
+	}
+	meta.Comments = append(meta.Comments, api.FileComment{
+		ID:        id,
+		Author:    req.Username,
+		Text:      text,
+		CreatedAt: time.Now().UTC(),
+	})
+	meta.ModifiedAt = time.Now().UTC()
+	if err := s.saveFileMetadata(ctx.storageUser, ctx.baseDEK, meta); err != nil {
+		return api.Response{Success: false, Message: "Error al guardar comentario"}
+	}
+	return api.Response{Success: true, Message: "Comentario añadido", FileMetadata: &meta}
+}

--- a/pkg/server/file_metadata.go
+++ b/pkg/server/file_metadata.go
@@ -386,11 +386,19 @@ func (s *server) loadPermissionTree(username string, _ []byte, path string, incl
 	if err != nil {
 		return nil, err
 	}
+	return s.loadPermissionTreeForContext(username, ctx, normalized, includeTarget, nil)
+}
 
+func (s *server) loadPermissionTreeForContext(username string, ctx fileAccessContext, path string, includeTarget bool, targetInfo os.FileInfo) ([]api.FileMetadata, error) {
+	normalized := normalizedFilePath(path)
 	if ctx.isShared {
-		rootInfo, err := os.Stat(sharedFolderRootAbsPath(ctx.owner))
-		if err != nil {
-			return nil, err
+		rootInfo := targetInfo
+		if normalized != ctx.rootPath || rootInfo == nil {
+			var err error
+			rootInfo, err = os.Stat(sharedFolderRootAbsPath(ctx.owner))
+			if err != nil {
+				return nil, err
+			}
 		}
 		rootMeta, err := s.ensureFileMetadata(ctx.storageUser, ctx.baseDEK, ctx.rootPath, rootInfo)
 		if err != nil {
@@ -406,9 +414,13 @@ func (s *server) loadPermissionTree(username string, _ []byte, path string, incl
 		}
 		for _, prefix := range prefixes {
 			absPath := filepath.Join(ctx.baseDir, filepath.FromSlash(prefix))
-			info, err := os.Stat(absPath)
-			if err != nil {
-				return nil, err
+			info := targetInfo
+			if prefix != normalized || info == nil {
+				var err error
+				info, err = os.Stat(absPath)
+				if err != nil {
+					return nil, err
+				}
 			}
 			meta, err := s.ensureFileMetadata(ctx.storageUser, ctx.baseDEK, prefix, info)
 			if err != nil {
@@ -426,9 +438,13 @@ func (s *server) loadPermissionTree(username string, _ []byte, path string, incl
 	}
 	for _, prefix := range prefixes {
 		absPath := filepath.Join(ctx.baseDir, filepath.FromSlash(prefix))
-		info, err := os.Stat(absPath)
-		if err != nil {
-			return nil, err
+		info := targetInfo
+		if prefix != normalized || info == nil {
+			var err error
+			info, err = os.Stat(absPath)
+			if err != nil {
+				return nil, err
+			}
 		}
 		meta, err := s.ensureFileMetadata(ctx.storageUser, ctx.baseDEK, prefix, info)
 		if err != nil {
@@ -450,6 +466,17 @@ func (s *server) hasPermissionThroughTree(username string, tree []api.FileMetada
 
 func (s *server) requirePathPermission(username string, dek []byte, path string, includeTarget bool, permission byte) api.Response {
 	tree, err := s.loadPermissionTree(username, dek, path, includeTarget)
+	if err != nil {
+		return api.Response{Success: false, Message: "Error al obtener permisos del arbol"}
+	}
+	if !s.hasPermissionThroughTree(username, tree, permission) {
+		return api.Response{Success: false, Message: "Permiso denegado"}
+	}
+	return api.Response{Success: true}
+}
+
+func (s *server) requirePathPermissionForContext(username string, ctx fileAccessContext, path string, includeTarget bool, permission byte, targetInfo os.FileInfo) api.Response {
+	tree, err := s.loadPermissionTreeForContext(username, ctx, path, includeTarget, targetInfo)
 	if err != nil {
 		return api.Response{Success: false, Message: "Error al obtener permisos del arbol"}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -230,8 +230,12 @@ func (s *server) apiHandler(w http.ResponseWriter, r *http.Request) {
 		res = s.updateFileMetadata(req)
 	case api.ActionFilterFilesByTag:
 		res = s.filterFilesByTag(req)
+	case api.ActionListFileComments:
+		res = s.listFileComments(req)
 	case api.ActionAddFileComment:
 		res = s.addFileComment(req)
+	case api.ActionDeleteFileComment:
+		res = s.deleteFileComment(req)
 	case api.ActionSharedFolderAddMember:
 		res = s.sharedFolderAddMember(req)
 	case api.ActionSharedFolderRemoveMember:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -230,6 +230,8 @@ func (s *server) apiHandler(w http.ResponseWriter, r *http.Request) {
 		res = s.updateFileMetadata(req)
 	case api.ActionFilterFilesByTag:
 		res = s.filterFilesByTag(req)
+	case api.ActionAddFileComment:
+		res = s.addFileComment(req)
 	case api.ActionSharedFolderAddMember:
 		res = s.sharedFolderAddMember(req)
 	case api.ActionSharedFolderRemoveMember:

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -378,6 +378,190 @@ func TestServer_FileCommentsBasicLifecycle(t *testing.T) {
 	if strings.Contains(string(dbBytes), "revisar este fichero") {
 		t.Fatal("el comentario quedo en claro en server.db")
 	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:      api.ActionAddFileComment,
+		Username:    "alice",
+		Token:       token,
+		Path:        "nota.txt",
+		CommentText: "   ",
+	})
+	if r.Success {
+		t.Fatal("addFileComment deberia rechazar comentarios vacios")
+	}
+}
+
+func TestServer_FileCommentsSharedVisibilityAndDeleteRules(t *testing.T) {
+	ts, _ := newRolesTestServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	aliceToken := registerAndLogin(t, httpClient, apiURL, "alice", "password123")
+	bobToken := registerAndLogin(t, httpClient, apiURL, "bob", "password123")
+	charlieToken := registerAndLogin(t, httpClient, apiURL, "charlie", "password123")
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateDir,
+		Username: "alice",
+		Token:    aliceToken,
+		Path:     "compartida_alice",
+	})
+	if !r.Success {
+		t.Fatalf("create shared folder fallo: %s", r.Message)
+	}
+	for _, username := range []string{"bob", "charlie"} {
+		_, r = postJSON(t, httpClient, apiURL, api.Request{
+			Action:     api.ActionSharedFolderAddMember,
+			Username:   "alice",
+			Token:      aliceToken,
+			Path:       "compartida_alice",
+			TargetUser: username,
+		})
+		if !r.Success {
+			t.Fatalf("sharedFolderAddMember %q fallo: %s", username, r.Message)
+		}
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    aliceToken,
+		Path:     "compartida_alice/nota.txt",
+		Data:     "contenido compartido",
+	})
+	if !r.Success {
+		t.Fatalf("create shared file fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:      api.ActionAddFileComment,
+		Username:    "bob",
+		Token:       bobToken,
+		Path:        "compartida_alice/nota.txt",
+		CommentText: "comentario de bob",
+	})
+	if !r.Success || r.FileMetadata == nil || len(r.FileMetadata.Comments) != 1 {
+		t.Fatalf("bob deberia poder comentar en compartida: success=%v msg=%q meta=%+v", r.Success, r.Message, r.FileMetadata)
+	}
+	bobCommentID := r.FileMetadata.Comments[0].ID
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionListFileComments,
+		Username: "alice",
+		Token:    aliceToken,
+		Path:     "compartida_alice/nota.txt",
+	})
+	if !r.Success || r.FileMetadata == nil || len(r.FileMetadata.Comments) != 1 || r.FileMetadata.Comments[0].Text != "comentario de bob" {
+		t.Fatalf("alice deberia ver comentario compartido: success=%v msg=%q meta=%+v", r.Success, r.Message, r.FileMetadata)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:    api.ActionDeleteFileComment,
+		Username:  "charlie",
+		Token:     charlieToken,
+		Path:      "compartida_alice/nota.txt",
+		CommentID: bobCommentID,
+	})
+	if r.Success {
+		t.Fatal("charlie no deberia borrar comentarios ajenos sin ser propietario")
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:    api.ActionDeleteFileComment,
+		Username:  "bob",
+		Token:     bobToken,
+		Path:      "compartida_alice/nota.txt",
+		CommentID: bobCommentID,
+	})
+	if !r.Success || r.FileMetadata == nil || len(r.FileMetadata.Comments) != 0 {
+		t.Fatalf("bob deberia borrar su propio comentario: success=%v msg=%q meta=%+v", r.Success, r.Message, r.FileMetadata)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:      api.ActionAddFileComment,
+		Username:    "bob",
+		Token:       bobToken,
+		Path:        "compartida_alice/nota.txt",
+		CommentText: "otro comentario",
+	})
+	if !r.Success || r.FileMetadata == nil || len(r.FileMetadata.Comments) != 1 {
+		t.Fatalf("bob deberia poder comentar de nuevo: success=%v msg=%q meta=%+v", r.Success, r.Message, r.FileMetadata)
+	}
+	bobCommentID = r.FileMetadata.Comments[0].ID
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:    api.ActionDeleteFileComment,
+		Username:  "alice",
+		Token:     aliceToken,
+		Path:      "compartida_alice/nota.txt",
+		CommentID: bobCommentID,
+	})
+	if !r.Success || r.FileMetadata == nil || len(r.FileMetadata.Comments) != 0 {
+		t.Fatalf("alice propietaria deberia borrar comentario: success=%v msg=%q meta=%+v", r.Success, r.Message, r.FileMetadata)
+	}
+}
+
+func TestServer_FileCommentsRequireReadPermission(t *testing.T) {
+	ts, _ := newRolesTestServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	aliceToken := registerAndLogin(t, httpClient, apiURL, "alice", "password123")
+	bobToken := registerAndLogin(t, httpClient, apiURL, "bob", "password123")
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateDir,
+		Username: "alice",
+		Token:    aliceToken,
+		Path:     "compartida_alice",
+	})
+	if !r.Success {
+		t.Fatalf("create shared folder fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:     api.ActionSharedFolderAddMember,
+		Username:   "alice",
+		Token:      aliceToken,
+		Path:       "compartida_alice",
+		TargetUser: "bob",
+	})
+	if !r.Success {
+		t.Fatalf("sharedFolderAddMember fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    aliceToken,
+		Path:     "compartida_alice/nota.txt",
+		Data:     "contenido compartido",
+	})
+	if !r.Success {
+		t.Fatalf("create shared file fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionUpdateFileMetadata,
+		Username: "alice",
+		Token:    aliceToken,
+		Path:     "compartida_alice/nota.txt",
+		Data:     "rw-------",
+	})
+	if !r.Success {
+		t.Fatalf("updateFileMetadata fallo: %s", r.Message)
+	}
+
+	for _, action := range []string{api.ActionListFileComments, api.ActionAddFileComment} {
+		_, r = postJSON(t, httpClient, apiURL, api.Request{
+			Action:      action,
+			Username:    "bob",
+			Token:       bobToken,
+			Path:        "compartida_alice/nota.txt",
+			CommentText: "no permitido",
+		})
+		if r.Success {
+			t.Fatalf("%s deberia fallar sin permiso de lectura", action)
+		}
+	}
 }
 
 func TestServer_FileMetadataRejectsInvalidTokenAndTraversal(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -307,6 +307,79 @@ func TestServer_FileMetadataLifecycle(t *testing.T) {
 	}
 }
 
+func TestServer_FileCommentsBasicLifecycle(t *testing.T) {
+	ts, _, dbPath := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:           api.ActionRegister,
+		Username:         "alice",
+		Password:         "password123",
+		MessagePublicKey: newTestPublicKey(t),
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("createFile fallo: %s", r.Message)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:      api.ActionAddFileComment,
+		Username:    "alice",
+		Token:       token,
+		Path:        "nota.txt",
+		CommentText: "revisar este fichero",
+	})
+	if !r.Success || r.FileMetadata == nil {
+		t.Fatalf("addFileComment fallo: success=%v msg=%q", r.Success, r.Message)
+	}
+	if len(r.FileMetadata.Comments) != 1 {
+		t.Fatalf("comentarios inesperados: %+v", r.FileMetadata.Comments)
+	}
+	comment := r.FileMetadata.Comments[0]
+	if comment.ID == "" || comment.Author != "alice" || comment.Text != "revisar este fichero" || comment.CreatedAt.IsZero() {
+		t.Fatalf("comentario invalido: %+v", comment)
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionGetFileMetadata,
+		Username: "alice",
+		Token:    token,
+		Path:     "nota.txt",
+	})
+	if !r.Success || r.FileMetadata == nil || len(r.FileMetadata.Comments) != 1 {
+		t.Fatalf("getFileMetadata no devolvio comentario: success=%v msg=%q meta=%+v", r.Success, r.Message, r.FileMetadata)
+	}
+
+	dbBytes, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("no se pudo leer server.db: %v", err)
+	}
+	if strings.Contains(string(dbBytes), "revisar este fichero") {
+		t.Fatal("el comentario quedo en claro en server.db")
+	}
+}
+
 func TestServer_FileMetadataRejectsInvalidTokenAndTraversal(t *testing.T) {
 	ts, _, _ := newTestTLSServer(t)
 	apiURL := ts.URL + "/api"

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -389,6 +389,78 @@ func TestServer_FileCommentsBasicLifecycle(t *testing.T) {
 	if r.Success {
 		t.Fatal("addFileComment deberia rechazar comentarios vacios")
 	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:      api.ActionAddFileComment,
+		Username:    "alice",
+		Token:       token,
+		Path:        "nota.txt",
+		CommentText: strings.Repeat("x", maxFileCommentBytes+1),
+	})
+	if r.Success {
+		t.Fatal("addFileComment deberia rechazar comentarios demasiado largos")
+	}
+}
+
+func TestServer_FileCommentsLimitPerFile(t *testing.T) {
+	ts, _, _ := newTestTLSServer(t)
+	apiURL := ts.URL + "/api"
+	httpClient := ts.Client()
+	httpClient.Timeout = 2 * time.Second
+
+	_, r := postJSON(t, httpClient, apiURL, api.Request{
+		Action:           api.ActionRegister,
+		Username:         "alice",
+		Password:         "password123",
+		MessagePublicKey: newTestPublicKey(t),
+	})
+	if !r.Success {
+		t.Fatalf("register fallo: %s", r.Message)
+	}
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionLogin,
+		Username: "alice",
+		Password: "password123",
+	})
+	if !r.Success {
+		t.Fatalf("login fallo: %s", r.Message)
+	}
+	token := r.Token
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:   api.ActionCreateFile,
+		Username: "alice",
+		Token:    token,
+		Path:     "limite.txt",
+		Data:     "contenido",
+	})
+	if !r.Success {
+		t.Fatalf("createFile fallo: %s", r.Message)
+	}
+
+	for i := 0; i < maxFileCommentsPerFile; i++ {
+		_, r = postJSON(t, httpClient, apiURL, api.Request{
+			Action:      api.ActionAddFileComment,
+			Username:    "alice",
+			Token:       token,
+			Path:        "limite.txt",
+			CommentText: "comentario",
+		})
+		if !r.Success {
+			t.Fatalf("addFileComment %d fallo: %s", i, r.Message)
+		}
+	}
+
+	_, r = postJSON(t, httpClient, apiURL, api.Request{
+		Action:      api.ActionAddFileComment,
+		Username:    "alice",
+		Token:       token,
+		Path:        "limite.txt",
+		CommentText: "comentario extra",
+	})
+	if r.Success {
+		t.Fatal("addFileComment deberia rechazar comentarios al superar el limite por fichero")
+	}
 }
 
 func TestServer_FileCommentsSharedVisibilityAndDeleteRules(t *testing.T) {


### PR DESCRIPTION
## Referencias

Closes #50

## Descripción

Se añade soporte para crear, listar y borrar comentarios asociados a los metadatos de cada fichero o carpeta. Los comentarios quedan cifrados junto al resto de metadatos, funcionan tanto en rutas propias como en carpetas compartidas, y respetan los permisos lógicos existentes: para ver o añadir comentarios hace falta permiso de lectura sobre la ruta.

También se actualiza el cliente para:
- ver comentarios con su ID desde la opción específica de comentarios;
- añadir comentarios y mostrarlos en los metadatos sin exponer el ID;
- borrar comentarios mostrando previamente los comentarios propios con su ID para poder elegir cuál eliminar.

## Tipo de cambio

- [x] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Seguridad
- [ ] Refactor

## Checklist

- [x] El servidor arranca sin errores (`go run main.go`)
- [x] He probado el flujo completo (registro → login → operación → logout)
- [x] No hay contraseñas ni secretos hardcodeados

## Revisión

### Revisores

<!-- Añade los revisores que deben aprobar este PR -->
<!--   - @usuario1 -->

## Checklist de revisión

- [ ] El código compila sin errores (`go build ./...`)
- [ ] Los tests pasan (`go test ./...`)
- [ ] No hay contraseñas ni secretos hardcodeados
- [ ] Los errores se manejan correctamente (no hay `_` ignorando errores importantes)
- [ ] Las funciones nuevas son coherentes con el estilo del resto del proyecto
- [ ] No se exponen endpoints innecesarios
- [ ] He probado el flujo manualmente